### PR TITLE
src: Include assert.h from node_api_helpers.h

### DIFF
--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -12,6 +12,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "node_jsvmapi.h"
 #include "node_asyncapi.h"
+#include <assert.h>
 #include <limits.h>
 #include <string.h>
 


### PR DESCRIPTION
node_api_helpers.h calls `assert()` in places, so the header needs to be included.