### PR TITLE
Fix implementation of napi_create_boolean

### DIFF
--- a/src/node_jsrtapi.cc
+++ b/src/node_jsrtapi.cc
@@ -501,7 +501,7 @@ napi_value napi_create_number(napi_env e, double v) {
 napi_value napi_create_boolean(napi_env e, bool b) {
   JsErrorCode error = JsNoError;
   JsValueRef booleanValue = nullptr;
-  error = JsDoubleToNumber(b, &booleanValue);
+  error = JsBoolToBoolean(b, &booleanValue);
   return reinterpret_cast<napi_value>(booleanValue);
 }
 


### PR DESCRIPTION
This is a leftover copy/paste error that causes booleans to be rendered as numbers when they return to JS.