### PR TITLE
Add comment about own properties

### DIFF
--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -177,6 +177,7 @@ NODE_EXTERN napi_propertyname napi_property_name(napi_env e,
 NODE_EXTERN napi_value napi_get_propertynames(napi_env e, napi_value object);
 NODE_EXTERN void napi_set_property(napi_env e, napi_value object,
                                    napi_propertyname name, napi_value v);
+// How do we distinguish between own and prototype properties?
 NODE_EXTERN bool napi_has_property(napi_env e, napi_value object,
                                    napi_propertyname name);
 NODE_EXTERN napi_value napi_get_property(napi_env e, napi_value object,


### PR DESCRIPTION
##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

JS VM Api

##### Description of change
<!-- provide a description of the change below this comment -->

Not V8 related, but do we need methods for own properties as well? Also, do we need a method that returns the property without invoking getters and interceptors (similar to v8::GetRealNamedProperty)? 
