### PR TITLE
Remove comment regarding releasing weakrefs

### DIFF
--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -260,7 +260,6 @@ NODE_EXTERN napi_value napi_get_persistent_value(napi_env e, napi_persistent p);
 NODE_EXTERN napi_weakref napi_create_weakref(napi_env e, napi_value v);
 NODE_EXTERN bool napi_get_weakref_value(napi_env e, napi_weakref w,
                                         napi_value *pv);
-// is this actually needed?
 NODE_EXTERN void napi_release_weakref(napi_env e, napi_weakref w);
 NODE_EXTERN napi_handle_scope napi_open_handle_scope(napi_env e);
 NODE_EXTERN void napi_close_handle_scope(napi_env e, napi_handle_scope s);


### PR DESCRIPTION
##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
JS VM Api

##### Description of change
<!-- provide a description of the change below this comment -->
I think V8 can't distinguish between `persistent` and `weakref`, so the method to release weakrefs is needed. 

`value` and `persistent` is about lifetime, not stack vs heap, right? If `napi_value` can be stored on the heap, we need to careful in V8 to handle this correctly. Is the section about "Methods to control object lifespan" pretty much in its final form?
