### PR TITLE
Property accessors 6.2.0

### DIFF
--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -1,4 +1,4 @@
-#ifndef SRC_NODE_API_HELPERS_H_
+﻿#ifndef SRC_NODE_API_HELPERS_H_
 #define SRC_NODE_API_HELPERS_H_
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -17,7 +17,9 @@
 #include <assert.h>
 
 #define NAPI_METHOD(name)                                                      \
-  void name(napi_env env, napi_func_cb_info info)
+  void name(napi_env env, napi_callback_info info)
+#define NAPI_GETTER(name) NAPI_METHOD(name)
+#define NAPI_SETTER(name) NAPI_METHOD(name)
 
 #define NAPI_MODULE_INIT(name)                                                 \
   void name(napi_env env, napi_value exports, napi_value module)

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -143,7 +143,8 @@ NODE_EXTERN napi_value napi_create_symbol(napi_env e, const char* s = NULL);
 // to be included.  Same for napi_create_object, and perhaps add a
 // napi_set_external_data() and get api?  Consider JsCreateExternalObject and
 // v8::ObjectTemplate::SetInternalFieldCount()
-NODE_EXTERN napi_value napi_create_function(napi_env e, napi_callback cbinfo);
+NODE_EXTERN napi_value napi_create_function(napi_env e, napi_callback cb,
+                                            void* data);
 NODE_EXTERN napi_value napi_create_error(napi_env e, napi_value msg);
 NODE_EXTERN napi_value napi_create_type_error(napi_env e, napi_value msg);
 
@@ -188,6 +189,8 @@ NODE_EXTERN void napi_set_element(napi_env e, napi_value object,
 NODE_EXTERN bool napi_has_element(napi_env e, napi_value object, uint32_t i);
 NODE_EXTERN napi_value napi_get_element(napi_env e,
                                         napi_value object, uint32_t i);
+NODE_EXTERN void napi_define_property(napi_env e, napi_value object,
+                                      napi_property_descriptor* property);
 
 
 // Methods to work with Arrays
@@ -221,14 +224,15 @@ NODE_EXTERN napi_value napi_make_callback(napi_env e, napi_value recv,
 
 
 // Methods to work with napi_callbacks
-NODE_EXTERN int napi_get_cb_args_length(napi_env e, napi_func_cb_info cbinfo);
-NODE_EXTERN void napi_get_cb_args(napi_env e, napi_func_cb_info cbinfo,
+NODE_EXTERN int napi_get_cb_args_length(napi_env e, napi_callback_info cbinfo);
+NODE_EXTERN void napi_get_cb_args(napi_env e, napi_callback_info cbinfo,
                                   napi_value* buffer, size_t bufferlength);
-NODE_EXTERN napi_value napi_get_cb_this(napi_env e, napi_func_cb_info cbinfo);
+NODE_EXTERN napi_value napi_get_cb_this(napi_env e, napi_callback_info cbinfo);
 // V8 concept; see note in .cc file
-NODE_EXTERN napi_value napi_get_cb_holder(napi_env e, napi_func_cb_info cbinfo);
-NODE_EXTERN bool napi_is_construct_call(napi_env e, napi_func_cb_info cbinfo);
-NODE_EXTERN void napi_set_return_value(napi_env e, napi_func_cb_info cbinfo,
+NODE_EXTERN napi_value napi_get_cb_holder(napi_env e, napi_callback_info cbinfo);
+NODE_EXTERN void* napi_get_cb_data(napi_env e, napi_callback_info cbinfo);
+NODE_EXTERN bool napi_is_construct_call(napi_env e, napi_callback_info cbinfo);
+NODE_EXTERN void napi_set_return_value(napi_env e, napi_callback_info cbinfo,
                                        napi_value v);
 
 
@@ -242,19 +246,17 @@ NODE_EXTERN void napi_set_return_value(napi_env e, napi_func_cb_info cbinfo,
 // best way to attach external data to a javascript object.  Perhaps
 // instead NAPI should do an external data concept like JsSetExternalData
 // and use that for "wrapping a native object".
-NODE_EXTERN napi_value napi_create_constructor_for_wrap(napi_env e,
-                                                        napi_callback cb);
 NODE_EXTERN void napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
-                           napi_destruct* napi_destructor,
+                           napi_destruct napi_destructor,
                            napi_weakref* handle);
 NODE_EXTERN void* napi_unwrap(napi_env e, napi_value jsObject);
-
-NODE_EXTERN napi_value napi_create_constructor_for_wrap_with_methods(
+NODE_EXTERN napi_value napi_create_constructor(
   napi_env e,
-  napi_callback cb,
   char* utf8name,
-  int methodcount,
-  napi_method_descriptor* methods);
+  napi_callback cb,
+  void* data,
+  int property_count,
+  napi_property_descriptor* properties);
 
 // Methods to control object lifespan
 NODE_EXTERN napi_persistent napi_create_persistent(napi_env e, napi_value v);

--- a/src/node_jsvmapi_types.h
+++ b/src/node_jsvmapi_types.h
@@ -1,4 +1,4 @@
-#ifndef SRC_NODE_JSVMAPI_TYPES_H_
+﻿#ifndef SRC_NODE_JSVMAPI_TYPES_H_
 #define SRC_NODE_JSVMAPI_TYPES_H_
 
 // JSVM API types are all opaque pointers for ABI stability
@@ -10,15 +10,28 @@ typedef struct napi_weakref__ *napi_weakref;
 typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_propertyname__ *napi_propertyname;
-typedef struct napi_func_cb_info__ *napi_func_cb_info;
-typedef void (*napi_callback)(napi_env, napi_func_cb_info);
-typedef void napi_destruct(void* v);
+typedef struct napi_callback_info__ *napi_callback_info;
 
+typedef void (*napi_callback)(napi_env, napi_callback_info);
+typedef void (*napi_destruct)(void* v);
 
-struct napi_method_descriptor {
-  napi_callback callback;
-  const char* utf8name;
+enum napi_property_attributes {
+  napi_default = 0,
+  napi_read_only = 1 << 0,
+  napi_dont_enum = 1 << 1,
+  napi_dont_delete = 1 << 2
 };
 
+struct napi_property_descriptor {
+  const char* utf8name;
+
+  napi_callback method;
+  napi_callback getter;
+  napi_callback setter;
+  napi_value value;
+
+  napi_property_attributes attributes;
+  void* data;
+};
 
 #endif  // SRC_NODE_JSVMAPI_TYPES_H_

--- a/test/addons-abi/1_hello_world/binding.cc
+++ b/test/addons-abi/1_hello_world/binding.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Method(napi_env env, napi_func_cb_info info) {
+void Method(napi_env env, napi_callback_info info) {
   napi_set_return_value(
         env,
         info,
@@ -8,9 +8,8 @@ void Method(napi_env env, napi_func_cb_info info) {
 }
 
 void Init(napi_env env, napi_value exports, napi_value module) {
-  napi_set_property(env, exports,
-                    napi_property_name(env, "hello"),
-                    napi_create_function(env, Method));
+  napi_property_descriptor desc = { "hello", Method };
+  napi_define_property(env, exports, &desc);
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/2_function_arguments/binding.cc
+++ b/test/addons-abi/2_function_arguments/binding.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Add(napi_env env, napi_func_cb_info info) {
+void Add(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -24,9 +24,8 @@ void Add(napi_env env, napi_func_cb_info info) {
 
 
 void Init(napi_env env, napi_value exports, napi_value module) {
-  napi_set_property(env, exports,
-                    napi_property_name(env, "add"),
-                    napi_create_function(env, Add));
+  napi_property_descriptor addDescriptor = { "add", Add };
+  napi_define_property(env, exports, &addDescriptor);
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/3_callbacks/binding.cc
+++ b/test/addons-abi/3_callbacks/binding.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void RunCallback(napi_env env, const napi_func_cb_info info) {
+void RunCallback(napi_env env, const napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
   napi_value cb = args[0];
@@ -11,9 +11,8 @@ void RunCallback(napi_env env, const napi_func_cb_info info) {
 }
 
 void Init(napi_env env, napi_value exports, napi_value module) {
-  napi_set_property(env, module,
-                        napi_property_name(env, "exports"),
-                        napi_create_function(env, RunCallback));
+  napi_property_descriptor desc = { "exports", RunCallback };
+  napi_define_property(env, module, &desc);
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/4_object_factory/binding.cc
+++ b/test/addons-abi/4_object_factory/binding.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void napi_create_object(napi_env env, const napi_func_cb_info info) {
+void CreateObject(napi_env env, const napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
 
@@ -12,9 +12,8 @@ void napi_create_object(napi_env env, const napi_func_cb_info info) {
 }
 
 void Init(napi_env env, napi_value exports, napi_value module) {
-  napi_set_property(env, module,
-                        napi_property_name(env, "exports"),
-                        napi_create_function(env, napi_create_object));
+  napi_property_descriptor desc = { "exports", CreateObject };
+  napi_define_property(env, module, &desc);
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/5_function_factory/binding.cc
+++ b/test/addons-abi/5_function_factory/binding.cc
@@ -1,11 +1,11 @@
 #include <node_jsvmapi.h>
 
-void MyFunction(napi_env env, napi_func_cb_info info) {
+void MyFunction(napi_env env, napi_callback_info info) {
   napi_set_return_value(env, info, napi_create_string(env, "hello world"));
 }
 
-void napi_create_function(napi_env env, napi_func_cb_info info) {
-  napi_value fn = napi_create_function(env, MyFunction);
+void CreateFunction(napi_env env, napi_callback_info info) {
+  napi_value fn = napi_create_function(env, MyFunction, nullptr);
 
   // omit this to make it anonymous
   napi_set_function_name(env, fn, napi_property_name(env, "theFunction"));
@@ -14,9 +14,8 @@ void napi_create_function(napi_env env, napi_func_cb_info info) {
 }
 
 void Init(napi_env env, napi_value exports, napi_value module) {
-  napi_set_property(env, module,
-                        napi_property_name(env, "exports"),
-                        napi_create_function(env, napi_create_function));
+  napi_property_descriptor desc = { "exports", CreateFunction };
+  napi_define_property(env, module, &desc);
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/6_object_wrap/myobject.h
+++ b/test/addons-abi/6_object_wrap/myobject.h
@@ -12,10 +12,11 @@ class MyObject {
   explicit MyObject(double value_ = 0);
   ~MyObject();
 
-  static void New(napi_env env, napi_func_cb_info info);
-  static void GetValue(napi_env env, napi_func_cb_info info);
-  static void PlusOne(napi_env env, napi_func_cb_info info);
-  static void Multiply(napi_env env, napi_func_cb_info info);
+  static void New(napi_env env, napi_callback_info info);
+  static void GetValue(napi_env env, napi_callback_info info);
+  static void SetValue(napi_env env, napi_callback_info info);
+  static void PlusOne(napi_env env, napi_callback_info info);
+  static void Multiply(napi_env env, napi_callback_info info);
   static napi_persistent constructor;
   double value_;
 };

--- a/test/addons-abi/6_object_wrap/test.js
+++ b/test/addons-abi/6_object_wrap/test.js
@@ -3,14 +3,17 @@ require('../../common');
 var assert = require('assert');
 var addon = require('./build/Release/binding');
 
-var obj = new addon.MyObject(10);
+var obj = new addon.MyObject(9);
+assert.equal(obj.value, 9);
+obj.value = 10;
+assert.equal(obj.value, 10);
 assert.equal(obj.plusOne(), 11);
 assert.equal(obj.plusOne(), 12);
 assert.equal(obj.plusOne(), 13);
 
-assert.equal(obj.multiply().napi_value(), 13);
-assert.equal(obj.multiply(10).napi_value(), 130);
+assert.equal(obj.multiply().value, 13);
+assert.equal(obj.multiply(10).value, 130);
 
 var newobj = obj.multiply(-1);
-assert.equal(newobj.napi_value(), -13);
+assert.equal(newobj.value, -13);
 assert(obj !== newobj);

--- a/test/addons-abi/7_factory_wrap/binding.cc
+++ b/test/addons-abi/7_factory_wrap/binding.cc
@@ -1,6 +1,6 @@
 #include "myobject.h"
 
-void napi_create_object(napi_env env, napi_func_cb_info info) {
+void CreateObject(napi_env env, napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
   napi_set_return_value(env, info, MyObject::NewInstance(env, args[0]));
@@ -8,9 +8,8 @@ void napi_create_object(napi_env env, napi_func_cb_info info) {
 
 void Init(napi_env env, napi_value exports, napi_value module) {
   MyObject::Init(env);
-  napi_set_property(env, module,
-                        napi_property_name(env, "exports"),
-                        napi_create_function(env, napi_create_object));
+  napi_property_descriptor desc = { "exports", CreateObject };
+  napi_define_property(env, module, &desc);
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/7_factory_wrap/myobject.cc
+++ b/test/addons-abi/7_factory_wrap/myobject.cc
@@ -10,21 +10,15 @@ void MyObject::Destructor(void* nativeObject) {
 napi_persistent MyObject::constructor;
 
 void MyObject::Init(napi_env env) {
-  napi_value function = napi_create_constructor_for_wrap(env, New);
-  napi_set_function_name(env, function, napi_property_name(env, "MyObject"));
-  napi_value prototype =
-    napi_get_property(env, function, napi_property_name(env, "prototype"));
-
-  napi_value plusOneFunction = napi_create_function(env, PlusOne);
-  napi_set_function_name(env, plusOneFunction,
-                         napi_property_name(env, "plusOne"));
-  napi_set_property(env, prototype, napi_property_name(env, "plusOne"),
-                        plusOneFunction);
-
-  constructor = napi_create_persistent(env, function);
+  napi_property_descriptor properties[] = {
+    { "plusOne", PlusOne },
+  };
+  napi_value cons = napi_create_constructor(env, "MyObject", New,
+                                            nullptr, 1, properties);
+  constructor = napi_create_persistent(env, cons);
 }
 
-void MyObject::New(napi_env env, napi_func_cb_info info) {
+void MyObject::New(napi_env env, napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
   MyObject* obj = new MyObject();
@@ -44,7 +38,7 @@ napi_value MyObject::NewInstance(napi_env env, napi_value arg) {
   return napi_new_instance(env, cons, argc, argv);
 }
 
-void MyObject::PlusOne(napi_env env, napi_func_cb_info info) {
+void MyObject::PlusOne(napi_env env, napi_callback_info info) {
   MyObject* obj = reinterpret_cast<MyObject*>(
                       napi_unwrap(env, napi_get_cb_this(env, info)));
   obj->counter_ += 1;

--- a/test/addons-abi/7_factory_wrap/myobject.h
+++ b/test/addons-abi/7_factory_wrap/myobject.h
@@ -14,8 +14,8 @@ class MyObject {
   ~MyObject();
 
   static napi_persistent constructor;
-  static void New(napi_env env, napi_func_cb_info info);
-  static void PlusOne(napi_env env, napi_func_cb_info info);
+  static void New(napi_env env, napi_callback_info info);
+  static void PlusOne(napi_env env, napi_callback_info info);
   double counter_;
 };
 

--- a/test/addons-abi/8_passing_wrapped/binding.cc
+++ b/test/addons-abi/8_passing_wrapped/binding.cc
@@ -1,12 +1,12 @@
 #include "myobject.h"
 
-void napi_create_object(napi_env env, napi_func_cb_info info) {
+void CreateObject(napi_env env, napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
   napi_set_return_value(env, info, MyObject::NewInstance(env, args[0]));
 }
 
-void Add(napi_env env, napi_func_cb_info info) {
+void Add(napi_env env, napi_callback_info info) {
   napi_value args[2];
   napi_get_cb_args(env, info, args, 2);
   MyObject* obj1 = reinterpret_cast<MyObject*>(napi_unwrap(env, args[0]));
@@ -18,14 +18,11 @@ void Add(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   MyObject::Init(env);
 
-  napi_set_property(env, exports,
-              napi_property_name(env, "createObject"),
-              napi_create_function(env, napi_create_object));
+  napi_property_descriptor desc = { "createObject", CreateObject };
+  napi_define_property(env, exports, &desc);
 
-
-  napi_set_property(env, exports,
-              napi_property_name(env, "add"),
-              napi_create_function(env, Add));
+  napi_property_descriptor desc2 = { "add", Add };
+  napi_define_property(env, exports, &desc2);
 }
 
 

--- a/test/addons-abi/8_passing_wrapped/myobject.cc
+++ b/test/addons-abi/8_passing_wrapped/myobject.cc
@@ -11,13 +11,11 @@ void MyObject::Destructor(void* nativeObject) {
 napi_persistent MyObject::constructor;
 
 void MyObject::Init(napi_env env) {
-  napi_value function = napi_create_constructor_for_wrap(env, New);
-  napi_set_function_name(env, function, napi_property_name(env, "MyObject"));
-
-  constructor = napi_create_persistent(env, function);
+  napi_value cons = napi_create_constructor(env, "MyObject", New, nullptr, 0, nullptr);
+  constructor = napi_create_persistent(env, cons);
 }
 
-void MyObject::New(napi_env env, napi_func_cb_info info) {
+void MyObject::New(napi_env env, napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
   MyObject* obj = new MyObject();

--- a/test/addons-abi/8_passing_wrapped/myobject.h
+++ b/test/addons-abi/8_passing_wrapped/myobject.h
@@ -15,7 +15,7 @@ class MyObject {
   ~MyObject();
 
   static napi_persistent constructor;
-  static void New(napi_env env, napi_func_cb_info info);
+  static void New(napi_env env, napi_callback_info info);
   double val_;
 };
 

--- a/test/addons-abi/test_array/test_array.cc
+++ b/test/addons-abi/test_array/test_array.cc
@@ -1,7 +1,7 @@
 #include <node_jsvmapi.h>
 #include <string.h>
 
-void Test(napi_env env, napi_func_cb_info info) {
+void Test(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -22,7 +22,7 @@ void Test(napi_env env, napi_func_cb_info info) {
   }
 
   napi_value array = args[0];
-  int index = napi_get_number_from_value(env, args[1]);
+  int index = napi_get_value_int32(env, args[1]);
   if (napi_is_array(env, array)) {
     int size = napi_get_array_length(env, array);
     if (index >= size) {
@@ -37,7 +37,7 @@ void Test(napi_env env, napi_func_cb_info info) {
   }
 }
 
-void New(napi_env env, napi_func_cb_info info) {
+void New(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -64,11 +64,11 @@ void New(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "Test"),
-                    napi_create_function(env, Test));
+                    napi_create_function(env, Test, nullptr));
 
   napi_set_property(env, exports,
                     napi_property_name(env, "New"),
-                    napi_create_function(env, New));
+                    napi_create_function(env, New, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_constructor/binding.gyp
+++ b/test/addons-abi/test_constructor/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_constructor",
+      "sources": [ "test_constructor.cc" ]
+    }
+  ]
+}

--- a/test/addons-abi/test_constructor/test.js
+++ b/test/addons-abi/test_constructor/test.js
@@ -1,0 +1,28 @@
+'use strict';
+require('../../common');
+var assert = require('assert');
+
+// Testing api calls for a constructor that defines properties
+var TestConstructor = require('./build/Release/test_constructor');
+var test_object = new TestConstructor();
+
+assert.equal(test_object.echo('hello'), 'hello');
+
+test_object.readwriteValue = 1;
+assert.equal(test_object.readwriteValue, 1);
+test_object.readwriteValue = 2;
+assert.equal(test_object.readwriteValue, 2);
+
+assert.throws(() => { test_object.readonlyValue = 3; });
+
+assert.ok(test_object.hiddenValue);
+
+// All properties except 'hiddenValue' should be enumerable.
+var propertyNames = [];
+for (var name in test_object) {
+  propertyNames.push(name);
+}
+assert.ok(propertyNames.indexOf('echo') >= 0);
+assert.ok(propertyNames.indexOf('readwriteValue') >= 0);
+assert.ok(propertyNames.indexOf('readonlyValue') >= 0);
+assert.ok(propertyNames.indexOf('hiddenValue') < 0);

--- a/test/addons-abi/test_constructor/test_constructor.cc
+++ b/test/addons-abi/test_constructor/test_constructor.cc
@@ -1,0 +1,63 @@
+#include <node_jsvmapi.h>
+
+static double value_ = 1;
+napi_persistent constructor_;
+
+void GetValue(napi_env env, napi_callback_info info) {
+  if (napi_get_cb_args_length(env, info) != 0) {
+    napi_throw_type_error(env, "Wrong number of arguments");
+    return;
+  }
+
+  napi_value number = napi_create_number(env, value_);
+  napi_set_return_value(env, info, number);
+}
+
+void SetValue(napi_env env, napi_callback_info info) {
+  if (napi_get_cb_args_length(env, info) != 1) {
+    napi_throw_type_error(env, "Wrong number of arguments");
+    return;
+  }
+
+  napi_value arg;
+  napi_get_cb_args(env, info, &arg, 1);
+
+  value_ = napi_get_number_from_value(env, arg);
+}
+
+void Echo(napi_env env, napi_callback_info info) {
+  if (napi_get_cb_args_length(env, info) != 1) {
+    napi_throw_type_error(env, "Wrong number of arguments");
+    return;
+  }
+
+  napi_value arg;
+  napi_get_cb_args(env, info, &arg, 1);
+
+  napi_set_return_value(env, info, arg);
+}
+
+void New(napi_env env, napi_callback_info info) {
+  napi_value jsthis = napi_get_cb_this(env, info);
+  napi_set_return_value(env, info, jsthis);
+}
+
+void Init(napi_env env, napi_value exports, napi_value module) {
+  napi_value number = napi_create_number(env, value_);
+  napi_property_descriptor properties[] = {
+    { "echo", Echo },
+    { "accessorValue", nullptr, GetValue, SetValue },
+    { "readwriteValue", nullptr, nullptr, nullptr, number },
+    { "readonlyValue", nullptr, nullptr, nullptr, number, napi_read_only },
+    { "hiddenValue", nullptr, nullptr, nullptr, number,
+      static_cast<napi_property_attributes>(napi_read_only | napi_dont_enum) },
+  };
+  napi_value cons = napi_create_constructor(env, "MyObject", New,
+    nullptr, sizeof(properties)/sizeof(*properties), properties);
+
+  napi_set_property(env, module, napi_property_name(env, "exports"),
+                    cons);
+  constructor_ = napi_create_persistent(env, cons);
+}
+
+NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_exception/test_exception.cc
+++ b/test/addons-abi/test_exception/test_exception.cc
@@ -32,13 +32,13 @@ NAPI_METHOD(wasPending) {
 NAPI_MODULE_INIT(Init) {
   napi_set_property(env, exports,
                     napi_property_name(env, "returnException"),
-                    napi_create_function(env, returnException));
+                    napi_create_function(env, returnException, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "allowException"),
-                    napi_create_function(env, allowException));
+                    napi_create_function(env, allowException, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "wasPending"),
-                    napi_create_function(env, wasPending));
+                    napi_create_function(env, wasPending, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_function/test_function.cc
+++ b/test/addons-abi/test_function/test_function.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Test(napi_env env, napi_func_cb_info info) {
+void Test(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -28,7 +28,7 @@ void Test(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "Test"),
-                    napi_create_function(env, Test));
+                    napi_create_function(env, Test, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_instanceof/test_instanceof.cc
+++ b/test/addons-abi/test_instanceof/test_instanceof.cc
@@ -1,7 +1,7 @@
 #include <node_jsvmapi.h>
 #include <stdio.h>
 
-void doInstanceOf(napi_env env, napi_func_cb_info info) {
+void doInstanceOf(napi_env env, napi_callback_info info) {
   napi_value arguments[2];
 
   napi_get_cb_args(env, info, arguments, 2);
@@ -13,7 +13,7 @@ void doInstanceOf(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "doInstanceOf"),
-                    napi_create_function(env, doInstanceOf));
+                    napi_create_function(env, doInstanceOf, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_number/test_number.cc
+++ b/test/addons-abi/test_number/test_number.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Test(napi_env env, napi_func_cb_info info) {
+void Test(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -22,7 +22,7 @@ void Test(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "Test"),
-                    napi_create_function(env, Test));
+                    napi_create_function(env, Test, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_object/test_object.cc
+++ b/test/addons-abi/test_object/test_object.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Get(napi_env env, napi_func_cb_info info) {
+void Get(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -32,7 +32,7 @@ void Get(napi_env env, napi_func_cb_info info) {
   }
 }
 
-void Has(napi_env env, napi_func_cb_info info) {
+void Has(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -65,7 +65,7 @@ void Has(napi_env env, napi_func_cb_info info) {
   }
 }
 
-void New(napi_env env, napi_func_cb_info info) {
+void New(napi_env env, napi_callback_info info) {
   napi_value ret = napi_create_object(env);
 
   napi_propertyname test_number = napi_property_name(env, "test_number");
@@ -77,7 +77,7 @@ void New(napi_env env, napi_func_cb_info info) {
   napi_set_return_value(env, info, ret);
 }
 
-void Inflate(napi_env env, napi_func_cb_info info) {
+void Inflate(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -111,16 +111,16 @@ void Inflate(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "Get"),
-                    napi_create_function(env, Get));
+                    napi_create_function(env, Get, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "Has"),
-                    napi_create_function(env, Has));
+                    napi_create_function(env, Has, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "New"),
-                    napi_create_function(env, New));
+                    napi_create_function(env, New, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "Inflate"),
-                    napi_create_function(env, Inflate));
+                    napi_create_function(env, Inflate, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_properties/binding.gyp
+++ b/test/addons-abi/test_properties/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_properties",
+      "sources": [ "test_properties.cc" ]
+    }
+  ]
+}

--- a/test/addons-abi/test_properties/test.js
+++ b/test/addons-abi/test_properties/test.js
@@ -1,0 +1,27 @@
+'use strict';
+require('../../common');
+var assert = require('assert');
+
+// Testing api calls for defining properties
+var test_object = require('./build/Release/test_properties');
+
+assert.equal(test_object.echo('hello'), 'hello');
+
+test_object.readwriteValue = 1;
+assert.equal(test_object.readwriteValue, 1);
+test_object.readwriteValue = 2;
+assert.equal(test_object.readwriteValue, 2);
+
+assert.throws(() => { test_object.readonlyValue = 3; });
+
+assert.ok(test_object.hiddenValue);
+
+// All properties except 'hiddenValue' should be enumerable.
+var propertyNames = [];
+for (var name in test_object) {
+  propertyNames.push(name);
+}
+assert.ok(propertyNames.indexOf('echo') >= 0);
+assert.ok(propertyNames.indexOf('readwriteValue') >= 0);
+assert.ok(propertyNames.indexOf('readonlyValue') >= 0);
+assert.ok(propertyNames.indexOf('hiddenValue') < 0);

--- a/test/addons-abi/test_properties/test_properties.cc
+++ b/test/addons-abi/test_properties/test_properties.cc
@@ -1,0 +1,55 @@
+#include <node_jsvmapi.h>
+
+static double value_ = 1;
+
+void GetValue(napi_env env, napi_callback_info info) {
+  if (napi_get_cb_args_length(env, info) != 0) {
+    napi_throw_type_error(env, "Wrong number of arguments");
+    return;
+  }
+
+  napi_value number = napi_create_number(env, value_);
+  napi_set_return_value(env, info, number);
+}
+
+void SetValue(napi_env env, napi_callback_info info) {
+  if (napi_get_cb_args_length(env, info) != 1) {
+    napi_throw_type_error(env, "Wrong number of arguments");
+    return;
+  }
+
+  napi_value arg;
+  napi_get_cb_args(env, info, &arg, 1);
+
+  value_ = napi_get_number_from_value(env, arg);
+}
+
+void Echo(napi_env env, napi_callback_info info) {
+  if (napi_get_cb_args_length(env, info) != 1) {
+    napi_throw_type_error(env, "Wrong number of arguments");
+    return;
+  }
+
+  napi_value arg;
+  napi_get_cb_args(env, info, &arg, 1);
+
+  napi_set_return_value(env, info, arg);
+}
+
+void Init(napi_env env, napi_value exports, napi_value module) {
+  napi_value number = napi_create_number(env, value_);
+  napi_property_descriptor properties[] = {
+    { "echo", Echo },
+    { "accessorValue", nullptr, GetValue, SetValue },
+    { "readwriteValue", nullptr, nullptr, nullptr, number },
+    { "readonlyValue", nullptr, nullptr, nullptr, number, napi_read_only },
+    { "hiddenValue", nullptr, nullptr, nullptr, number,
+      static_cast<napi_property_attributes>(napi_read_only | napi_dont_enum) },
+  };
+
+  for (int i = 0; i < sizeof(properties) / sizeof(*properties); i++) {
+    napi_define_property(env, exports, &properties[i]);
+  }
+}
+
+NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_string/test_string.cc
+++ b/test/addons-abi/test_string/test_string.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Copy(napi_env env, napi_func_cb_info info) {
+void Copy(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -25,7 +25,7 @@ void Copy(napi_env env, napi_func_cb_info info) {
   }
 }
 
-void Length(napi_env env, napi_func_cb_info info) {
+void Length(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -44,7 +44,7 @@ void Length(napi_env env, napi_func_cb_info info) {
   napi_set_return_value(env, info, output);
 }
 
-void Utf8Length(napi_env env, napi_func_cb_info info) {
+void Utf8Length(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -66,13 +66,13 @@ void Utf8Length(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "Copy"),
-                    napi_create_function(env, Copy));
+                    napi_create_function(env, Copy, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "Length"),
-                    napi_create_function(env, Length));
+                    napi_create_function(env, Length, nullptr));
   napi_set_property(env, exports,
                     napi_property_name(env, "Utf8Length"),
-                    napi_create_function(env, Utf8Length));
+                    napi_create_function(env, Utf8Length, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_symbol/test_symbol.cc
+++ b/test/addons-abi/test_symbol/test_symbol.cc
@@ -1,6 +1,6 @@
 #include <node_jsvmapi.h>
 
-void Test(napi_env env, napi_func_cb_info info) {
+void Test(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
     return;
@@ -25,7 +25,7 @@ void Test(napi_env env, napi_func_cb_info info) {
   }
 }
 
-void New(napi_env env, napi_func_cb_info info) {
+void New(napi_env env, napi_callback_info info) {
   if (napi_get_cb_args_length(env, info) >= 1) {
     napi_value args[1];
     napi_get_cb_args(env, info, args, 1);
@@ -50,7 +50,7 @@ void New(napi_env env, napi_func_cb_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_set_property(env, exports,
                     napi_property_name(env, "New"),
-                    napi_create_function(env, New));
+                    napi_create_function(env, New, nullptr));
 }
 
 NODE_MODULE_ABI(addon, Init)


### PR DESCRIPTION
See https://github.com/nodejs/abi-stable-node/issues/44

This change adds a new `napi_set_accessor` API which sets getter and setter accessors for a property on an object. In support of that, I refactored some of the callback-related code: the callback info opaque pointer type is now shared between function callbacks and accessor callbacks, so I renamed it from `napi_func_cb_info` to `napi_callback_info`, and renamed a few other things accordingly. In the internal implementation, there is a new `CallbackInfoWrapper` and subclasses that wrap the v8 `FunctionCallbackInfo` and `PropertyCallbackInfo` classes.

I assume we're not too concerned about breaking changes at this point, though of course any existing code using NAPI will need to be updated. I am updating the `abi-stable-node-addon-examples` repo for these changes, along with new examples for using property accessors.