### PR TITLE
InstanceOf 6.2.0

### DIFF
--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -206,6 +206,7 @@ NODE_EXTERN napi_value napi_call_function(napi_env e, napi_value scope,
                                           int argc, napi_value* argv);
 NODE_EXTERN napi_value napi_new_instance(napi_env e, napi_value cons,
                                          int argc, napi_value* argv);
+NODE_EXTERN bool napi_instanceof(napi_env e, napi_value obj, napi_value cons);
 
 // Temporary method needed to support wrapping JavascriptObject in an external 
 // object wrapper capable of storing external data. This workaround is only 


### PR DESCRIPTION
Adding a `napi_instanceof` API that checks whether a `napi_value` object is an instance created by a `napi_value` constructor function.

The V8 implementation isn't entirely trivial: V8 code would normally use `FunctionTemplate::HasInstance()`, except here we don't have the `FunctionTemplate` available because (as a V8-only concept) it is not exposed via NAPI. So instead we can implement the instance-of logic in a slightly less efficient way by looking through the prototype chain. (The JSRT implementation can simply call `JsInstanceOf()`.)

I started porting the `canvas` package and found it makes frequent use of `FunctionTemplate::HasInstance()` checks to support sort of polymorphic behavior for drawing different kinds of things on the canvas. The `sqlite3` package use the API in one place, just for a simple argument check. Based on my previous scans, not very many other packages use it.