### PR TITLE
Add api calls for supporting node-sqlite3

### DIFF
--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -24,6 +24,13 @@
 #define NAPI_MODULE_INIT(name)                                                 \
   void name(napi_env env, napi_value exports, napi_value module)
 
+#define NAPI_GETTER(name)                                                      \
+  void name(napi_env e, napi_propertyname property, napi_callback_info info)
+
+#define NAPI_SETTER(name)                                                      \
+  void name(napi_env e, napi_propertyname property, napi_value value,          \
+            napi_callback_info info)
+
 // This is taken from NAN and is the C++11 version.
 // TODO(ianhall): Support pre-C++11 compilation?
 #define NAPI_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&) = delete;
@@ -38,6 +45,289 @@
   NAPI_DISALLOW_MOVE(CLASS)
 
 namespace Napi {
+  inline napi_value Value() {
+    napi_env env = napi_get_current_env();
+    return napi_new_value(env);
+  }
+
+
+  // Napi::New helpers
+  inline napi_value New() {
+    return napi_get_null(napi_get_current_env());
+  }
+  inline napi_value New(bool val) {
+    return napi_create_boolean(napi_get_current_env(), val);
+  }
+  inline napi_value New(int val) {
+    return napi_create_number(napi_get_current_env(), val);
+  }
+  inline napi_value New(double val) {
+    return napi_create_number(napi_get_current_env(), val);
+  }
+  inline napi_value New(const char* val) {
+    return napi_create_string(napi_get_current_env(), val);
+  }
+  inline napi_value New(const char* val, size_t len) {
+    return napi_create_string_with_length(napi_get_current_env(), val, len);
+  }
+  inline napi_value New(napi_persistent p) {
+    napi_env env = napi_get_current_env();
+    return napi_get_persistent_value(env, p);
+  }
+  inline napi_value NewSymbol(const char* val) {
+    return napi_create_symbol(napi_get_current_env(), val);
+  }
+  inline napi_value NewObject() {
+    return napi_create_object(napi_get_current_env());
+  }
+  inline napi_value NewArray() {
+    return napi_create_array(napi_get_current_env());
+  }
+  inline napi_value NewArray(int len) {
+    return napi_create_array_with_length(napi_get_current_env(), len);
+  }
+  inline napi_value NewFunction(napi_callback cb) {
+    napi_env env = napi_get_current_env();
+    return napi_create_function(env, cb, NULL);
+  }
+
+
+  inline napi_value Undefined() {
+    return napi_get_undefined_(napi_get_current_env());
+  }
+
+  inline napi_value Null() {
+    return napi_get_null(napi_get_current_env());
+  }
+
+  // Error Helpers
+  inline napi_value Error(const char* errmsg) {
+    napi_env env = napi_get_current_env();
+    return napi_create_error(env, napi_create_string(env, errmsg));
+  }
+  inline napi_value Error(napi_value errmsg) {
+    napi_env env = napi_get_current_env();
+    return napi_create_error(env, errmsg);
+  }
+
+  inline napi_value TypeError(const char* errmsg) {
+    napi_env env = napi_get_current_env();
+    return napi_create_type_error(env, napi_create_string(env, errmsg));
+  }
+  inline napi_value TypeError(napi_value errmsg) {
+    napi_env env = napi_get_current_env();
+    return napi_create_type_error(env, errmsg);
+  }
+
+  // Error Helpers
+  inline void ThrowError(char* errmsg) {
+    napi_env env = napi_get_current_env();
+    napi_throw_error(env, errmsg);
+  }
+  inline void ThrowError(napi_value errmsg) {
+    napi_env env = napi_get_current_env();
+    napi_throw(env, napi_create_error(env, errmsg));
+  }
+  inline void ThrowTypeError(char* errmsg) {
+    napi_env env = napi_get_current_env();
+    napi_throw_type_error(env, errmsg);
+  }
+  inline void ThrowTypeError(napi_value errmsg) {
+    napi_env env = napi_get_current_env();
+    napi_throw(env, napi_create_type_error(env, errmsg));
+  }
+
+  // Get helpers
+  inline napi_value GetPropertyNames(napi_value obj) {
+    napi_env env = napi_get_current_env();
+    return napi_get_propertynames(env, obj);
+  }
+
+  inline napi_value Get(napi_value obj, napi_propertyname key ) {
+    napi_env env = napi_get_current_env();
+    return napi_get_property(env, obj, key);
+  }
+  inline napi_value Get(napi_value obj, const char* name) {
+    napi_env env = napi_get_current_env();
+    napi_propertyname key = napi_property_name(env, name);
+    return napi_get_property(env, obj, key);
+  }
+  inline napi_value Get(napi_value obj, napi_value name) {
+    napi_env env = napi_get_current_env();
+    napi_propertyname key = reinterpret_cast<napi_propertyname>(name);
+    return napi_get_property(env, obj, key);
+  }
+  inline napi_value Get(napi_value arr, uint32_t i ) {
+    napi_env env = napi_get_current_env();
+    return napi_get_element(env, arr, i);
+  }
+
+  // Set  helpers
+  inline void Set(napi_value obj, napi_propertyname key, napi_value val) {
+    napi_env env = napi_get_current_env();
+    napi_set_property(env, obj, key, val);
+  }
+  inline void Set(napi_value obj, const char* name, napi_value val) {
+    napi_env env = napi_get_current_env();
+    napi_propertyname key = napi_property_name(env, name);
+    napi_set_property(env, obj, key, val);
+  }
+  inline void Set(napi_value obj, napi_value name, napi_value val) {
+    napi_env env = napi_get_current_env();
+    napi_propertyname key = reinterpret_cast<napi_propertyname>(name);
+    napi_set_property(env, obj, key, val);
+  }
+  inline void Set(napi_value arr, uint32_t i, napi_value val) {
+    napi_env env = napi_get_current_env();
+    napi_set_element(env, arr, i, val);
+  }
+
+  // Type check helpers
+  inline bool IsEmpty(napi_value v) {
+    napi_env env = napi_get_current_env();
+    return napi_is_empty(env, v);
+  }
+  inline bool IsNumber(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_number;
+  }
+  inline bool IsInt32(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_is_int32(env, val);
+  }
+  inline bool IsString(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_string;
+  }
+  inline bool IsFunction(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_function;
+  }
+  inline bool IsObject(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_object;
+  }
+  inline bool IsArray(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_array;
+  }
+  inline bool IsBoolean(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_boolean;
+  }
+  inline bool IsUndefined(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_undefined;
+  }
+  inline bool IsSymbol(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_symbol;
+  }
+  inline bool IsRegExp(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_regexp;
+  }
+  inline bool IsDate(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_date;
+  }
+  inline bool IsNull(napi_value val) {
+    napi_env env = napi_get_current_env();
+    return napi_get_type_of_value(env, val) == napi_null;
+  }
+
+  inline bool HasInstance(napi_value tpl, napi_value obj) {
+    napi_env env = napi_get_current_env();
+    return napi_instanceof(env, obj, tpl);
+  }
+
+  inline napi_value CopyBuffer(const char* buf, uint32_t size) {
+    napi_env env = napi_get_current_env();
+    return napi_buffer_copy(env, buf, size);
+  }
+
+  inline napi_value StringConcat(napi_value str1, napi_value str2) {
+    napi_env env = napi_get_current_env();
+    return napi_string_concat(env, str1, str2);
+  }
+
+  inline napi_value MakeCallback(
+      napi_value target,
+      napi_value func,
+      int argc,
+      napi_value* argv
+  ) {
+    napi_env env = napi_get_current_env();
+    return napi_make_callback(env, target, func, argc, argv);
+  }
+
+  // Length helpers
+  inline int Length(napi_value val) {
+    napi_env env = napi_get_current_env();
+    assert(napi_get_type_of_value(env, val) == napi_array);
+    return napi_get_array_length(env, val);
+  }
+
+  inline int Length(napi_callback_info info) {
+    napi_env env = napi_get_current_env();
+    return napi_get_cb_args_length(env, info);
+  }
+
+  // Conversion helpers
+  inline void To(napi_value v, int32_t& o) {
+    napi_env env = napi_get_current_env();
+    o = napi_get_value_int32(env, v);
+  }
+
+  inline void To(napi_value v, uint32_t& o) {
+    napi_env env = napi_get_current_env();
+    o = napi_get_value_uint32(env, v);
+  }
+
+  inline void To(napi_value v, int64_t& o) {
+    napi_env env = napi_get_current_env();
+    o = napi_get_value_int64(env, v);
+  }
+
+  inline void To(napi_value v, bool& o) {
+    napi_env env = napi_get_current_env();
+    o = napi_get_value_bool(env, v);
+  }
+
+  inline void To(napi_value v, double& o) {
+    napi_env env = napi_get_current_env();
+    o = napi_get_number_from_value (env, v);
+  }
+
+  template<typename T>
+  inline T To(napi_value v) {
+    T ret;
+    To(v, ret);
+    return ret;
+  }
+
+  inline napi_value ToString(napi_value v) {
+    napi_env env = napi_get_current_env();
+    return napi_coerce_to_string(env, v);
+  }
+  inline napi_value ToObject(napi_value v) {
+    napi_env env = napi_get_current_env();
+    return napi_coerce_to_object(env, v);
+  }
+
+  inline bool Equals(napi_value lhs, napi_value rhs) {
+    napi_env env = napi_get_current_env();
+    return napi_strict_equals(env, lhs, rhs);
+  }
+
+  inline napi_value* GetArguments(napi_callback_info info) {
+    napi_env env = napi_get_current_env();
+    int len = napi_get_cb_args_length(env, info);
+    napi_value* args = (napi_value*) malloc(len * sizeof(napi_value));
+    napi_get_cb_args(env, info, args, len);
+    return args;
+  }
+
   // RAII HandleScope helpers
   // Mirror Nan versions for easy conversion
   // Ensure scopes are closed in the correct order on the stack
@@ -123,6 +413,84 @@ namespace Napi {
     char str_st_[1024];
   };
 
+  class ObjectWrap {
+   public:
+    ObjectWrap() {
+      napi_env env = napi_get_current_env();
+      handle_ = napi_create_persistent(env, nullptr);
+      refs_ = 0;
+    }
+
+    virtual ~ObjectWrap() {
+      napi_env env = napi_get_current_env();
+      napi_release_persistent(env, persistent());
+    }
+
+    template <class T>
+    static inline T* Unwrap(napi_value object) {
+      napi_env env = napi_get_current_env();
+      assert(!napi_is_empty(env, object));
+      assert(napi_get_internal_field_count(env, object) > 0);
+      void* ptr = napi_get_internal_field_pointer(env, object, 0);
+      ObjectWrap* wrap = static_cast<ObjectWrap*>(ptr);
+      return static_cast<T*>(wrap);
+    }
+
+    inline napi_value handle() {
+      napi_env env = napi_get_current_env();
+      return napi_get_persistent_value(env, persistent());
+    }
+
+    inline napi_persistent persistent() {
+      return handle_;
+    }
+
+   protected:
+    inline void Wrap(napi_value object) {
+      napi_env env = napi_get_current_env();
+      assert(napi_is_persistent_empty(env, persistent()));
+      assert(napi_get_internal_field_count(env, object) > 0);
+      napi_set_internal_field_pointer(env, object, 0, this);
+      napi_release_persistent(env, persistent());
+      handle_ = napi_create_persistent(env, object);
+      napi_persistent_make_weak(env, persistent(), this);
+    }
+
+    /* Ref() marks the object as being attached to an event loop.
+     * Refed objects will not be garbage collected, even if
+     * all references are lost.
+     */
+    virtual void Ref() {
+      napi_env env = napi_get_current_env();
+      assert(!napi_is_persistent_empty(env, persistent()));
+      napi_persistent_clear_weak(env, persistent());
+      refs_++;
+    }
+
+    /* Unref() marks an object as detached from the event loop.  This is its
+     * default state.  When an object with a "weak" reference changes from
+     * attached to detached state it will be freed. Be careful not to access
+     * the object after making this call as it might be gone!
+     * (A "weak reference" means an object that only has a
+     * persistent handle.)
+     *
+     * DO NOT CALL THIS FROM DESTRUCTOR
+     */
+    virtual void Unref() {
+      napi_env env = napi_get_current_env();
+      assert(!napi_is_persistent_empty(env, persistent()));
+      assert(refs_ > 0);
+      if (--refs_ == 0)
+        napi_persistent_make_weak(env, persistent(), this);
+    }
+
+    int refs_;
+
+   private:
+    napi_persistent handle_;
+};
+
+
   // TODO(ianhall): This class uses napi_get_current_env() extensively
   // does that make sense? will this behave correctly when passed around
   // workers?  Is there a good reason to have napi_env?
@@ -182,6 +550,15 @@ namespace Napi {
         int argc = 0,
         napi_value argv[] = 0) const {
       return this->Call(argc, argv);
+    }
+
+    inline bool IsFunction() {
+      HandleScope scope;
+      napi_env env = napi_get_current_env();
+      napi_value fn =
+          napi_get_element(env,
+              napi_get_persistent_value(env, handle), kCallbackIndex);
+      return napi_function == napi_get_type_of_value(env, fn);
     }
 
     inline void SetFunction(napi_value fn) {
@@ -339,10 +716,6 @@ namespace Napi {
 
     napi_work request;
 
-    virtual void Destroy() {
-        delete this;
-    }
-
     static void CallExecute(void* this_pointer){
       AsyncWorker* self = static_cast<AsyncWorker*>(this_pointer);
       self->Execute();
@@ -351,11 +724,6 @@ namespace Napi {
     static void CallWorkComplete(void* this_pointer) {
       AsyncWorker* self = static_cast<AsyncWorker*>(this_pointer);
       self->WorkComplete();
-    }
-
-    static void CallDestroy(void* this_pointer) {
-      AsyncWorker* self = static_cast<AsyncWorker*>(this_pointer);
-      self->Destroy();
     }
 
    protected:
@@ -398,9 +766,9 @@ namespace Napi {
     napi_async_set_data(req, static_cast<void*>(worker));
     napi_async_set_execute(req, &AsyncWorker::CallExecute);
     napi_async_set_complete(req, &AsyncWorker::CallWorkComplete);
-    napi_async_set_destroy(req, &AsyncWorker::CallDestroy);
     napi_async_queue_worker(req);
   }
+
 } // namespace Napi
 
 

--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -15,6 +15,7 @@
 #include <limits.h>
 #include <string.h>
 #include <assert.h>
+#include <vector>
 
 #define NAPI_METHOD(name)                                                      \
   void name(napi_env env, napi_callback_info info)
@@ -23,13 +24,6 @@
 
 #define NAPI_MODULE_INIT(name)                                                 \
   void name(napi_env env, napi_value exports, napi_value module)
-
-#define NAPI_GETTER(name)                                                      \
-  void name(napi_env e, napi_propertyname property, napi_callback_info info)
-
-#define NAPI_SETTER(name)                                                      \
-  void name(napi_env e, napi_propertyname property, napi_value value,          \
-            napi_callback_info info)
 
 // This is taken from NAN and is the C++11 version.
 // TODO(ianhall): Support pre-C++11 compilation?
@@ -45,286 +39,237 @@
   NAPI_DISALLOW_MOVE(CLASS)
 
 namespace Napi {
-  inline napi_value Value() {
-    napi_env env = napi_get_current_env();
-    return napi_new_value(env);
-  }
-
-
   // Napi::New helpers
-  inline napi_value New() {
-    return napi_get_null(napi_get_current_env());
+  inline napi_value New(napi_env env) {
+    return napi_new_empty_value(env);
   }
-  inline napi_value New(bool val) {
-    return napi_create_boolean(napi_get_current_env(), val);
+  inline napi_value New(napi_env env, bool val) {
+    return napi_create_boolean(env, val);
   }
-  inline napi_value New(int val) {
-    return napi_create_number(napi_get_current_env(), val);
+  inline napi_value New(napi_env env, int val) {
+    return napi_create_number(env, val);
   }
-  inline napi_value New(double val) {
-    return napi_create_number(napi_get_current_env(), val);
+  inline napi_value New(napi_env env, double val) {
+    return napi_create_number(env, val);
   }
-  inline napi_value New(const char* val) {
-    return napi_create_string(napi_get_current_env(), val);
+  inline napi_value New(napi_env env, const char* val) {
+    return napi_create_string(env, val);
   }
-  inline napi_value New(const char* val, size_t len) {
-    return napi_create_string_with_length(napi_get_current_env(), val, len);
+  inline napi_value New(napi_env env, const char* val, size_t len) {
+    return napi_create_string_with_length(env, val, len);
   }
-  inline napi_value New(napi_persistent p) {
-    napi_env env = napi_get_current_env();
+  inline napi_value New(napi_env env, napi_persistent p) {
     return napi_get_persistent_value(env, p);
   }
-  inline napi_value NewSymbol(const char* val) {
-    return napi_create_symbol(napi_get_current_env(), val);
+  inline napi_value NewSymbol(napi_env env, const char* val) {
+    return napi_create_symbol(env, val);
   }
-  inline napi_value NewObject() {
-    return napi_create_object(napi_get_current_env());
+  inline napi_value NewObject(napi_env env) {
+    return napi_create_object(env);
   }
-  inline napi_value NewArray() {
-    return napi_create_array(napi_get_current_env());
+  inline napi_value NewArray(napi_env env) {
+    return napi_create_array(env);
   }
-  inline napi_value NewArray(int len) {
-    return napi_create_array_with_length(napi_get_current_env(), len);
+  inline napi_value NewArray(napi_env env, int len) {
+    return napi_create_array_with_length(env, len);
   }
-  inline napi_value NewFunction(napi_callback cb) {
-    napi_env env = napi_get_current_env();
+  inline napi_value NewFunction(napi_env env, napi_callback cb) {
     return napi_create_function(env, cb, NULL);
   }
 
 
-  inline napi_value Undefined() {
-    return napi_get_undefined_(napi_get_current_env());
+  inline napi_value Undefined(napi_env env) {
+    return napi_get_undefined_(env);
   }
 
-  inline napi_value Null() {
-    return napi_get_null(napi_get_current_env());
+  inline napi_value Null(napi_env env) {
+    return napi_get_null(env);
   }
 
   // Error Helpers
-  inline napi_value Error(const char* errmsg) {
-    napi_env env = napi_get_current_env();
+  inline napi_value Error(napi_env env, const char* errmsg) {
     return napi_create_error(env, napi_create_string(env, errmsg));
   }
-  inline napi_value Error(napi_value errmsg) {
-    napi_env env = napi_get_current_env();
+  inline napi_value Error(napi_env env, napi_value errmsg) {
     return napi_create_error(env, errmsg);
   }
 
-  inline napi_value TypeError(const char* errmsg) {
-    napi_env env = napi_get_current_env();
+  inline napi_value TypeError(napi_env env, const char* errmsg) {
     return napi_create_type_error(env, napi_create_string(env, errmsg));
   }
-  inline napi_value TypeError(napi_value errmsg) {
-    napi_env env = napi_get_current_env();
+  inline napi_value TypeError(napi_env env, napi_value errmsg) {
     return napi_create_type_error(env, errmsg);
   }
 
   // Error Helpers
-  inline void ThrowError(char* errmsg) {
-    napi_env env = napi_get_current_env();
+  inline void ThrowError(napi_env env, char* errmsg) {
     napi_throw_error(env, errmsg);
   }
-  inline void ThrowError(napi_value errmsg) {
-    napi_env env = napi_get_current_env();
+  inline void ThrowError(napi_env env, napi_value errmsg) {
     napi_throw(env, napi_create_error(env, errmsg));
   }
-  inline void ThrowTypeError(char* errmsg) {
-    napi_env env = napi_get_current_env();
+  inline void ThrowTypeError(napi_env env, char* errmsg) {
     napi_throw_type_error(env, errmsg);
   }
-  inline void ThrowTypeError(napi_value errmsg) {
-    napi_env env = napi_get_current_env();
+  inline void ThrowTypeError(napi_env env, napi_value errmsg) {
     napi_throw(env, napi_create_type_error(env, errmsg));
   }
 
   // Get helpers
-  inline napi_value GetPropertyNames(napi_value obj) {
-    napi_env env = napi_get_current_env();
+  inline napi_value GetPropertyNames(napi_env env, napi_value obj) {
     return napi_get_propertynames(env, obj);
   }
 
-  inline napi_value Get(napi_value obj, napi_propertyname key ) {
-    napi_env env = napi_get_current_env();
+  inline napi_value Get(napi_env env, napi_value obj, napi_propertyname key ) {
     return napi_get_property(env, obj, key);
   }
-  inline napi_value Get(napi_value obj, const char* name) {
-    napi_env env = napi_get_current_env();
+  inline napi_value Get(napi_env env, napi_value obj, const char* name) {
     napi_propertyname key = napi_property_name(env, name);
     return napi_get_property(env, obj, key);
   }
-  inline napi_value Get(napi_value obj, napi_value name) {
-    napi_env env = napi_get_current_env();
+  inline napi_value Get(napi_env env, napi_value obj, napi_value name) {
     napi_propertyname key = reinterpret_cast<napi_propertyname>(name);
     return napi_get_property(env, obj, key);
   }
-  inline napi_value Get(napi_value arr, uint32_t i ) {
-    napi_env env = napi_get_current_env();
+  inline napi_value Get(napi_env env, napi_value arr, uint32_t i ) {
     return napi_get_element(env, arr, i);
   }
 
   // Set  helpers
-  inline void Set(napi_value obj, napi_propertyname key, napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline void Set(napi_env env, napi_value obj,
+                  napi_propertyname key, napi_value val) {
     napi_set_property(env, obj, key, val);
   }
-  inline void Set(napi_value obj, const char* name, napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline void Set(napi_env env, napi_value obj,
+                  const char* name, napi_value val) {
     napi_propertyname key = napi_property_name(env, name);
     napi_set_property(env, obj, key, val);
   }
-  inline void Set(napi_value obj, napi_value name, napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline void Set(napi_env env, napi_value obj,
+                  napi_value name, napi_value val) {
     napi_propertyname key = reinterpret_cast<napi_propertyname>(name);
     napi_set_property(env, obj, key, val);
   }
-  inline void Set(napi_value arr, uint32_t i, napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline void Set(napi_env env, napi_value arr, uint32_t i, napi_value val) {
     napi_set_element(env, arr, i, val);
   }
 
   // Type check helpers
-  inline bool IsEmpty(napi_value v) {
-    napi_env env = napi_get_current_env();
+  inline bool IsEmpty(napi_env env, napi_value v) {
     return napi_is_empty(env, v);
   }
-  inline bool IsNumber(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsNumber(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_number;
   }
-  inline bool IsInt32(napi_value val) {
-    napi_env env = napi_get_current_env();
-    return napi_is_int32(env, val);
-  }
-  inline bool IsString(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsString(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_string;
   }
-  inline bool IsFunction(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsFunction(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_function;
   }
-  inline bool IsObject(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsObject(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_object;
   }
-  inline bool IsArray(napi_value val) {
-    napi_env env = napi_get_current_env();
-    return napi_get_type_of_value(env, val) == napi_array;
-  }
-  inline bool IsBoolean(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsBoolean(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_boolean;
   }
-  inline bool IsUndefined(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsUndefined(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_undefined;
   }
-  inline bool IsSymbol(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsSymbol(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_symbol;
   }
-  inline bool IsRegExp(napi_value val) {
-    napi_env env = napi_get_current_env();
-    return napi_get_type_of_value(env, val) == napi_regexp;
+  inline bool IsArray(napi_env env, napi_value val) {
+    return napi_is_array(env, val);
   }
-  inline bool IsDate(napi_value val) {
-    napi_env env = napi_get_current_env();
-    return napi_get_type_of_value(env, val) == napi_date;
+  inline bool IsRegExp(napi_env env, napi_value val) {
+    return napi_is_regexp(env, val);
   }
-  inline bool IsNull(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline bool IsDate(napi_env env, napi_value val) {
+    return napi_is_date(env, val);
+  }
+  inline bool IsNull(napi_env env, napi_value val) {
     return napi_get_type_of_value(env, val) == napi_null;
   }
 
-  inline bool HasInstance(napi_value tpl, napi_value obj) {
-    napi_env env = napi_get_current_env();
+  inline bool HasInstance(napi_env env, napi_value tpl, napi_value obj) {
     return napi_instanceof(env, obj, tpl);
   }
 
-  inline napi_value CopyBuffer(const char* buf, uint32_t size) {
-    napi_env env = napi_get_current_env();
+  inline napi_value CopyBuffer(napi_env env, const char* buf, uint32_t size) {
     return napi_buffer_copy(env, buf, size);
   }
 
-  inline napi_value StringConcat(napi_value str1, napi_value str2) {
-    napi_env env = napi_get_current_env();
+  inline napi_value StringConcat(napi_env env,
+                                 napi_value str1, napi_value str2) {
     return napi_string_concat(env, str1, str2);
   }
 
   inline napi_value MakeCallback(
+      napi_env env,
       napi_value target,
       napi_value func,
       int argc,
       napi_value* argv
   ) {
-    napi_env env = napi_get_current_env();
     return napi_make_callback(env, target, func, argc, argv);
   }
 
   // Length helpers
-  inline int Length(napi_value val) {
-    napi_env env = napi_get_current_env();
+  inline int Length(napi_env env, napi_value val) {
     assert(napi_get_type_of_value(env, val) == napi_array);
     return napi_get_array_length(env, val);
   }
 
-  inline int Length(napi_callback_info info) {
-    napi_env env = napi_get_current_env();
+  inline int Length(napi_env env, napi_callback_info info) {
     return napi_get_cb_args_length(env, info);
   }
 
   // Conversion helpers
-  inline void To(napi_value v, int32_t& o) {
-    napi_env env = napi_get_current_env();
+  inline void To(napi_env env, napi_value v, int32_t& o) {
     o = napi_get_value_int32(env, v);
   }
 
-  inline void To(napi_value v, uint32_t& o) {
-    napi_env env = napi_get_current_env();
+  inline void To(napi_env env, napi_value v, uint32_t& o) {
     o = napi_get_value_uint32(env, v);
   }
 
-  inline void To(napi_value v, int64_t& o) {
-    napi_env env = napi_get_current_env();
+  inline void To(napi_env env, napi_value v, int64_t& o) {
     o = napi_get_value_int64(env, v);
   }
 
-  inline void To(napi_value v, bool& o) {
-    napi_env env = napi_get_current_env();
+  inline void To(napi_env env, napi_value v, bool& o) {
     o = napi_get_value_bool(env, v);
   }
 
-  inline void To(napi_value v, double& o) {
-    napi_env env = napi_get_current_env();
+  inline void To(napi_env env, napi_value v, double& o) {
     o = napi_get_number_from_value (env, v);
   }
 
   template<typename T>
-  inline T To(napi_value v) {
+  inline T To(napi_env env, napi_value v) {
     T ret;
-    To(v, ret);
+    To(env, v, ret);
     return ret;
   }
 
-  inline napi_value ToString(napi_value v) {
-    napi_env env = napi_get_current_env();
+  inline napi_value ToString(napi_env env, napi_value v) {
     return napi_coerce_to_string(env, v);
   }
-  inline napi_value ToObject(napi_value v) {
-    napi_env env = napi_get_current_env();
+  inline napi_value ToObject(napi_env env, napi_value v) {
     return napi_coerce_to_object(env, v);
   }
 
-  inline bool Equals(napi_value lhs, napi_value rhs) {
-    napi_env env = napi_get_current_env();
+  inline bool Equals(napi_env env, napi_value lhs, napi_value rhs) {
     return napi_strict_equals(env, lhs, rhs);
   }
 
-  inline napi_value* GetArguments(napi_callback_info info) {
-    napi_env env = napi_get_current_env();
+  inline std::vector<napi_value> GetArguments(napi_env env,
+                                              napi_callback_info info) {
     int len = napi_get_cb_args_length(env, info);
-    napi_value* args = (napi_value*) malloc(len * sizeof(napi_value));
-    napi_get_cb_args(env, info, args, len);
+    std::vector<napi_value> args;
+    args.reserve(len);
+    napi_get_cb_args(env, info, args.data(), args.size());
     return args;
   }
 
@@ -430,8 +375,8 @@ namespace Napi {
     static inline T* Unwrap(napi_value object) {
       napi_env env = napi_get_current_env();
       assert(!napi_is_empty(env, object));
-      assert(napi_get_internal_field_count(env, object) > 0);
-      void* ptr = napi_get_internal_field_pointer(env, object, 0);
+      assert(Napi::Has(env, object, "internal_field"));
+      void* ptr = Napi::Get(env, object, "internal_field");
       ObjectWrap* wrap = static_cast<ObjectWrap*>(ptr);
       return static_cast<T*>(wrap);
     }
@@ -449,8 +394,8 @@ namespace Napi {
     inline void Wrap(napi_value object) {
       napi_env env = napi_get_current_env();
       assert(napi_is_persistent_empty(env, persistent()));
-      assert(napi_get_internal_field_count(env, object) > 0);
-      napi_set_internal_field_pointer(env, object, 0, this);
+      assert(Napi::Has(env, object, "internal_field"));
+      Napi::Set(env, object, "internal_field", this);
       napi_release_persistent(env, persistent());
       handle_ = napi_create_persistent(env, object);
       napi_persistent_make_weak(env, persistent(), this);
@@ -768,7 +713,6 @@ namespace Napi {
     napi_async_set_complete(req, &AsyncWorker::CallWorkComplete);
     napi_async_queue_worker(req);
   }
-
 } // namespace Napi
 
 

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -715,6 +715,18 @@ void napi_define_property(napi_env e, napi_value o,
   }
 }
 
+bool napi_is_date(napi_env e, napi_value v) {
+  NAPI_PREAMBLE(e);
+  v8::Local<v8::Value> val = v8impl::V8LocalValueFromJsValue(v);
+  return val->IsDate();
+}
+
+bool napi_is_regexp(napi_env e, napi_value v) {
+  NAPI_PREAMBLE(e);
+  v8::Local<v8::Value> val = v8impl::V8LocalValueFromJsValue(v);
+  return val->IsRegExp();
+}
+
 bool napi_is_array(napi_env e, napi_value v) {
   NAPI_PREAMBLE(e);
   v8::Local<v8::Value> val = v8impl::V8LocalValueFromJsValue(v);
@@ -823,16 +835,10 @@ napi_valuetype napi_get_type_of_value(napi_env e, napi_value vv) {
     return napi_string;
   } else if (v->IsSymbol()) {
     return napi_symbol;
-  } else if (v->IsRegExp()) {
-    return napi_regexp;
-  } else if (v->IsDate()) {
-    return napi_date;
   } else if (v->IsFunction()) {
     // This test has to come before IsObject because IsFunction
     // implies IsObject
     return napi_function;
-  } else if (v->IsArray()) {
-    return napi_array;
   } else if (v->IsObject()) {
     return napi_object;
   } else if (v->IsBoolean()) {
@@ -844,16 +850,6 @@ napi_valuetype napi_get_type_of_value(napi_env e, napi_value vv) {
   } else {
     return napi_object;   // Is this correct?
   }
-}
-
-bool napi_is_int32(napi_env e, napi_value v) {
-  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(v);
-  return value->IsInt32();
-}
-
-bool napi_is_uint32(napi_env e, napi_value v) {
-  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(v);
-  return value->IsUint32();
 }
 
 bool napi_is_empty(napi_env env, napi_value v) {
@@ -888,7 +884,7 @@ napi_value napi_get_true(napi_env e) {
              v8::True(v8impl::V8IsolateFromJsEnv(e)));
 }
 
-napi_value napi_new_value(napi_env env) {
+napi_value napi_new_empty_value(napi_env env) {
   return v8impl::JsValueFromV8LocalValue(v8::Local<v8::Value>());
 }
 
@@ -1106,21 +1102,6 @@ void napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
 void* napi_unwrap(napi_env e, napi_value jsObject) {
   NAPI_PREAMBLE(e);
   return v8impl::ObjectWrapWrapper::Unwrap(jsObject);
-}
-
-int napi_get_internal_field_count(napi_env env, napi_value jsObject) {
-  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
-  return obj->InternalFieldCount();
-}
-
-void* napi_get_internal_field_pointer(napi_env env, napi_value jsObject, int index) {
-  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
-  return obj->GetAlignedPointerFromInternalField(index);
-}
-
-void napi_set_internal_field_pointer(napi_env env, napi_value jsObject, int index, void* nativeObj) {
-  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
-  obj->SetAlignedPointerInInternalField(index, nativeObj);
 }
 
 napi_persistent napi_create_persistent(napi_env e, napi_value v) {

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -112,6 +112,9 @@ enum napi_valuetype {
   napi_number,
   napi_string,
   napi_symbol,
+  napi_regexp,
+  napi_date,
+  napi_array,
   napi_object,
   napi_function,
 };
@@ -119,6 +122,8 @@ enum napi_valuetype {
 // Environment
 NODE_EXTERN napi_env napi_get_current_env();
 
+bool napi_is_empty(napi_env env, napi_value v);
+bool napi_is_persistent_empty(napi_env env, napi_persistent p);
 
 // Getters for defined singletons
 NODE_EXTERN napi_value napi_get_undefined_(napi_env e);
@@ -127,6 +132,7 @@ NODE_EXTERN napi_value napi_get_false(napi_env e);
 NODE_EXTERN napi_value napi_get_true(napi_env e);
 NODE_EXTERN napi_value napi_get_global_scope(napi_env e);
 
+NODE_EXTERN napi_value napi_new_value(napi_env env);
 
 // Methods to create Primitive types/Objects
 NODE_EXTERN napi_value napi_create_object(napi_env e);
@@ -151,6 +157,8 @@ NODE_EXTERN napi_value napi_create_type_error(napi_env e, napi_value msg);
 
 // Methods to get the the native napi_value from Primitive type
 NODE_EXTERN napi_valuetype napi_get_type_of_value(napi_env e, napi_value v);
+NODE_EXTERN bool napi_is_int32(napi_env e, napi_value v);
+NODE_EXTERN bool napi_is_uint32(napi_env e, napi_value v);
 NODE_EXTERN double napi_get_number_from_value(napi_env e, napi_value v);
 NODE_EXTERN int napi_get_string_from_value(napi_env e, napi_value v,
                                            char* buf, const int buf_size);
@@ -165,6 +173,8 @@ NODE_EXTERN int napi_get_string_length(napi_env e, napi_value v);
 NODE_EXTERN int napi_get_string_utf8_length(napi_env e, napi_value v);
 NODE_EXTERN int napi_get_string_utf8(napi_env e, napi_value v,
                                      char* buf, int bufsize);
+NODE_EXTERN napi_value napi_string_concat(napi_env e,
+                                          napi_value s1, napi_value s2);
 
 
 // Methods to coerce values
@@ -250,6 +260,11 @@ NODE_EXTERN void napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
                            napi_destruct napi_destructor,
                            napi_weakref* handle);
 NODE_EXTERN void* napi_unwrap(napi_env e, napi_value jsObject);
+
+NODE_EXTERN int napi_get_internal_field_count(napi_env env, napi_value jsObject);
+NODE_EXTERN void* napi_get_internal_field_pointer(napi_env env, napi_value jsObject, int index);
+NODE_EXTERN void napi_set_internal_field_pointer(napi_env env, napi_value jsObject,  int index, void* nativeObj);
+
 NODE_EXTERN napi_value napi_create_constructor(
   napi_env e,
   char* utf8name,
@@ -262,6 +277,8 @@ NODE_EXTERN napi_value napi_create_constructor(
 NODE_EXTERN napi_persistent napi_create_persistent(napi_env e, napi_value v);
 NODE_EXTERN void napi_release_persistent(napi_env e, napi_persistent p);
 NODE_EXTERN napi_value napi_get_persistent_value(napi_env e, napi_persistent p);
+NODE_EXTERN void napi_persistent_make_weak(napi_env env, napi_persistent p, void* v);
+NODE_EXTERN void napi_persistent_clear_weak(napi_env env, napi_persistent p);
 NODE_EXTERN napi_weakref napi_create_weakref(napi_env e, napi_value v);
 NODE_EXTERN bool napi_get_weakref_value(napi_env e, napi_weakref w,
                                         napi_value *pv);

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -112,9 +112,6 @@ enum napi_valuetype {
   napi_number,
   napi_string,
   napi_symbol,
-  napi_regexp,
-  napi_date,
-  napi_array,
   napi_object,
   napi_function,
 };
@@ -132,7 +129,7 @@ NODE_EXTERN napi_value napi_get_false(napi_env e);
 NODE_EXTERN napi_value napi_get_true(napi_env e);
 NODE_EXTERN napi_value napi_get_global_scope(napi_env e);
 
-NODE_EXTERN napi_value napi_new_value(napi_env env);
+NODE_EXTERN napi_value napi_new_empty_value(napi_env env);
 
 // Methods to create Primitive types/Objects
 NODE_EXTERN napi_value napi_create_object(napi_env e);
@@ -157,8 +154,6 @@ NODE_EXTERN napi_value napi_create_type_error(napi_env e, napi_value msg);
 
 // Methods to get the the native napi_value from Primitive type
 NODE_EXTERN napi_valuetype napi_get_type_of_value(napi_env e, napi_value v);
-NODE_EXTERN bool napi_is_int32(napi_env e, napi_value v);
-NODE_EXTERN bool napi_is_uint32(napi_env e, napi_value v);
 NODE_EXTERN double napi_get_number_from_value(napi_env e, napi_value v);
 NODE_EXTERN int napi_get_string_from_value(napi_env e, napi_value v,
                                            char* buf, const int buf_size);
@@ -201,6 +196,9 @@ NODE_EXTERN napi_value napi_get_element(napi_env e,
                                         napi_value object, uint32_t i);
 NODE_EXTERN void napi_define_property(napi_env e, napi_value object,
                                       napi_property_descriptor* property);
+
+NODE_EXTERN bool napi_is_date(napi_env e, napi_value v);
+NODE_EXTERN bool napi_is_regexp(napi_env e, napi_value v);
 
 
 // Methods to work with Arrays
@@ -260,10 +258,6 @@ NODE_EXTERN void napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
                            napi_destruct napi_destructor,
                            napi_weakref* handle);
 NODE_EXTERN void* napi_unwrap(napi_env e, napi_value jsObject);
-
-NODE_EXTERN int napi_get_internal_field_count(napi_env env, napi_value jsObject);
-NODE_EXTERN void* napi_get_internal_field_pointer(napi_env env, napi_value jsObject, int index);
-NODE_EXTERN void napi_set_internal_field_pointer(napi_env env, napi_value jsObject,  int index, void* nativeObj);
 
 NODE_EXTERN napi_value napi_create_constructor(
   napi_env e,

--- a/test/addons-abi/test_array/test_array.cc
+++ b/test/addons-abi/test_array/test_array.cc
@@ -10,7 +10,7 @@ void Test(napi_env env, napi_callback_info info) {
   napi_value args[2];
   napi_get_cb_args(env, info, args, 2);
 
-  if (napi_get_type_of_value(env, args[0]) != napi_object) {
+  if (napi_get_type_of_value(env, args[0]) != napi_array) {
     napi_throw_type_error(env,
         "Wrong type of argments. Expects an array as first argument.");
     return;
@@ -46,7 +46,7 @@ void New(napi_env env, napi_callback_info info) {
   napi_value args[1];
   napi_get_cb_args(env, info, args, 1);
 
-  if (napi_get_type_of_value(env, args[0]) != napi_object) {
+  if (napi_get_type_of_value(env, args[0]) != napi_array) {
     napi_throw_type_error(env,
         "Wrong type of argments. Expects an array as first argument.");
     return;


### PR DESCRIPTION
Added some api calls for supporting port node-sqlite3. Please review it and tell me if there is redundancy.

The interface keyword is causing failure in build, so changed it to struct.
The initialize list of CallbackWrapperBase has an error when build saying "need a primary expression before >", not sure what cause that so I changed it to the following
```
    CallbackWrapperBase(const T& cbinfo)
        : _cbinfo(cbinfo),
-         _cbdata(cbinfo.Data().As<v8::Object>()) {
+         _cbdata(v8::Local<v8::Object>::Cast(cbinfo.Data())) {
```