### PR TITLE
Fix incorrect use of scope term (V8)

### DIFF
--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -218,7 +218,7 @@ namespace Napi {
     inline napi_value
     Call(int argc, napi_value argv[]) const {
       napi_env env = napi_get_current_env();
-      return Call_(napi_get_global_scope(env), argc, argv);
+      return Call_(napi_get_global(env), argc, argv);
     }
 
    private:

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -911,22 +911,22 @@ void* napi_get_cb_data(napi_env e, napi_callback_info cbinfo) {
   return info->Data();
 }
 
-napi_value napi_call_function(napi_env e, napi_value scope,
+napi_value napi_call_function(napi_env e, napi_value recv,
                               napi_value func, int argc, napi_value* argv) {
   NAPI_PREAMBLE(e);
   std::vector<v8::Handle<v8::Value>> args(argc);
 
   v8::Local<v8::Function> v8func = v8impl::V8LocalFunctionFromJsValue(func);
-  v8::Handle<v8::Object> v8scope =
-      v8impl::V8LocalValueFromJsValue(scope)->ToObject();
+  v8::Handle<v8::Object> v8recv =
+      v8impl::V8LocalValueFromJsValue(recv)->ToObject();
   for (int i = 0; i < argc; i++) {
     args[i] = v8impl::V8LocalValueFromJsValue(argv[i]);
   }
-  v8::Handle<v8::Value> result = v8func->Call(v8scope, argc, args.data());
+  v8::Handle<v8::Value> result = v8func->Call(v8recv, argc, args.data());
   return v8impl::JsValueFromV8LocalValue(result);
 }
 
-napi_value napi_get_global_scope(napi_env e) {
+napi_value napi_get_global(napi_env e) {
   NAPI_PREAMBLE(e);
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
   // TODO(ianhall): what if we need the global object from a different

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -125,7 +125,7 @@ NODE_EXTERN napi_value napi_get_undefined_(napi_env e);
 NODE_EXTERN napi_value napi_get_null(napi_env e);
 NODE_EXTERN napi_value napi_get_false(napi_env e);
 NODE_EXTERN napi_value napi_get_true(napi_env e);
-NODE_EXTERN napi_value napi_get_global_scope(napi_env e);
+NODE_EXTERN napi_value napi_get_global(napi_env e);
 
 
 // Methods to create Primitive types/Objects
@@ -204,16 +204,16 @@ NODE_EXTERN bool napi_strict_equals(napi_env e, napi_value lhs, napi_value rhs);
 // Methods to work with Functions
 NODE_EXTERN void napi_set_function_name(napi_env e, napi_value func,
                                         napi_propertyname napi_value);
-NODE_EXTERN napi_value napi_call_function(napi_env e, napi_value scope,
+NODE_EXTERN napi_value napi_call_function(napi_env e, napi_value recv,
                                           napi_value func,
                                           int argc, napi_value* argv);
 NODE_EXTERN napi_value napi_new_instance(napi_env e, napi_value cons,
                                          int argc, napi_value* argv);
 NODE_EXTERN bool napi_instanceof(napi_env e, napi_value obj, napi_value cons);
 
-// Temporary method needed to support wrapping JavascriptObject in an external 
-// object wrapper capable of storing external data. This workaround is only 
-// required by ChakraCore and should be removed when we have a method of 
+// Temporary method needed to support wrapping JavascriptObject in an external
+// object wrapper capable of storing external data. This workaround is only
+// required by ChakraCore and should be removed when we have a method of
 // constructing external objects from the constructor function itself.
 NODE_EXTERN napi_value napi_make_external(napi_env e, napi_value v);
 

--- a/test/addons-abi/3_callbacks/binding.cc
+++ b/test/addons-abi/3_callbacks/binding.cc
@@ -7,7 +7,7 @@ void RunCallback(napi_env env, const napi_callback_info info) {
 
   napi_value argv[1];
   argv[0] = napi_create_string(env, "hello world");
-  napi_call_function(env, napi_get_global_scope(env) , cb, 1, argv);
+  napi_call_function(env, napi_get_global(env) , cb, 1, argv);
 }
 
 void Init(napi_env env, napi_value exports, napi_value module) {

--- a/test/addons-abi/test_exception/test_exception.cc
+++ b/test/addons-abi/test_exception/test_exception.cc
@@ -9,7 +9,7 @@ NAPI_METHOD(returnException) {
   napi_get_cb_args(env, info, &jsFunction, 1);
 
   // What is the return value when there was an exception?
-  napi_call_function(env, napi_get_global_scope(env), jsFunction, 0, 0);
+  napi_call_function(env, napi_get_global(env), jsFunction, 0, 0);
 
   napi_set_return_value(env, info, napi_get_and_clear_last_exception(env));
 }
@@ -19,7 +19,7 @@ NAPI_METHOD(allowException) {
 
   napi_get_cb_args(env, info, &jsFunction, 1);
 
-  napi_call_function(env, napi_get_global_scope(env), jsFunction, 0, 0);
+  napi_call_function(env, napi_get_global(env), jsFunction, 0, 0);
 
   exceptionWasPending = napi_is_exception_pending(env);
 }

--- a/test/addons-abi/test_function/test_function.cc
+++ b/test/addons-abi/test_function/test_function.cc
@@ -18,10 +18,7 @@ void Test(napi_env env, napi_callback_info info) {
   int argc = napi_get_cb_args_length(env, info) - 1;
   napi_value* argv = args + 1;
 
-  napi_escapable_handle_scope scope = napi_open_escapable_handle_scope(env);
-  napi_value scope_val = reinterpret_cast<napi_value> (scope);
-  napi_value output = napi_call_function(env, scope_val, function, argc, argv);
-  napi_close_escapable_handle_scope(env, scope);
+  napi_value output = napi_call_function(env, napi_get_global(env), function, argc, argv);
   napi_set_return_value(env, info, output);
 }
 


### PR DESCRIPTION
Fixes #64 for the V8 8.x branch. (Once this lands I'll also merge into the V8 6.x branch.)
For the chakracore version of this fix see #65.