### PR TITLE
Fix two build issues when building with GCC

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -189,7 +189,7 @@ namespace v8impl {
 
   // Interface implemented by classes that wrap V8 function and property
   // callback info.
-  interface CallbackWrapper {
+  struct CallbackWrapper {
     virtual napi_value This() = 0;
     virtual napi_value Holder() = 0;
     virtual bool IsConstructCall() = 0;
@@ -537,7 +537,8 @@ void napi_clear_last_error() {
 }
 
 const napi_extended_error_info* napi_get_last_error_info() {
-  static_assert(sizeof(error_messages) / sizeof(*error_messages) == napi_status_last);
+  static_assert(sizeof(error_messages) / sizeof(*error_messages) == napi_status_last, 
+    "Count of error messages must match count of error values");
   assert(static_last_error.error_code < napi_status_last);
 
   // Wait until someone requests the last error information to fetch the error message string


### PR DESCRIPTION
First, GCC doesn't seem to implement an interface keyword. Workaround here is to use struct instead of interface. This is https://github.com/nodejs/abi-stable-node/issues/69

Second, GCC doesn't support the flavor of static_assert which takes a single parameter. Just added a second parameter message here.