### PR TITLE
C++ wrapper classes

### DIFF
--- a/src/napi-inl.h
+++ b/src/napi-inl.h
@@ -1,0 +1,1484 @@
+﻿#ifndef SRC_NAPI_INL_H_
+#define SRC_NAPI_INL_H_
+
+////////////////////////////////////////////////////////////////////////////////
+// NAPI C++ Wrapper Classes
+//
+// Inline header-only implementations for "NAPI" ABI-stable C APIs for Node.js.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cassert>
+
+namespace Napi {
+
+// Adapt the NODE_MODULE registration function to NAPI:
+//  - Wrap the arguments in NAPI wrappers.
+//  - Catch any NAPI errors that might be thrown.
+#define NAPI_MODULE(modname, regfunc)                                                 \
+  void __napi_ ## regfunc(napi_env env, napi_value exports, napi_value module) {      \
+    try {                                                                             \
+      regfunc(Napi::Env(env), Napi::Object(env, exports), Napi::Object(env, module)); \
+    }                                                                                 \
+    catch (const Napi::Error&) {                                                      \
+      assert(false); /* Uncaught error in native module registration. */              \
+    }                                                                                 \
+  }                                                                                   \
+  NODE_MODULE_ABI(modname, __napi_ ## regfunc);
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Env class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Env::Env(napi_env env) : _env(env) {
+}
+
+inline Env::operator napi_env() const {
+  return _env;
+}
+inline Env Env::Current() {
+  napi_env env;
+  napi_status status = napi_get_current_env(&env);
+  if (status != napi_ok) env = nullptr; // Can't throw without an environment!
+  return Env(env);
+}
+
+inline Object Env::Global() const {
+  napi_value value;
+  napi_status status = napi_get_global(*this, &value);
+  if (status != napi_ok) throw const_cast<Env*>(this)->NewError();
+  return Object(*this, value);
+}
+
+inline Value Env::Undefined() const {
+  napi_value value;
+  napi_status status = napi_get_undefined(*this, &value);
+  if (status != napi_ok) throw const_cast<Env*>(this)->NewError();
+  return Value(*this, value);
+}
+
+inline Value Env::Null() const {
+  napi_value value;
+  napi_status status = napi_get_null(*this, &value);
+  if (status != napi_ok) throw const_cast<Env*>(this)->NewError();
+  return Value(*this, value);
+}
+
+inline Error Env::NewError() {
+  napi_value error;
+  if (IsExceptionPending()) {
+    napi_get_and_clear_last_exception(_env, &error);
+  }
+  else {
+    // No JS exception is pending, so check for NAPI error info.
+    const napi_extended_error_info* info = napi_get_last_error_info();
+
+    napi_value message;
+    napi_status status = napi_create_string_utf8(
+      _env,
+      info->error_message != nullptr ? info->error_message : "Error in native callback",
+      -1,
+      &message);
+    assert(status == napi_ok);
+
+    if (status == napi_ok) {
+      switch (info->error_code) {
+        case napi_object_expected:
+        case napi_string_expected:
+        case napi_boolean_expected:
+        case napi_number_expected:
+          status = napi_create_type_error(_env, message, &error);
+          break;
+        default:
+          status = napi_create_error(_env, message, &error);
+          break;
+      }
+      assert(status == napi_ok);
+    }
+  }
+
+  return Error(_env, error);
+}
+
+inline Error Env::NewError(const char* message) {
+  napi_value str;
+  napi_status status = napi_create_string_utf8(*this, message, -1, &str);
+  if (status != napi_ok) throw NewError();
+
+  napi_value error;
+  status = napi_create_error(*this, str, &error);
+  if (status != napi_ok) throw NewError();
+
+  return Error(*this, error);
+}
+
+inline Error Env::NewTypeError(const char* message) {
+  napi_value str;
+  napi_status status = napi_create_string_utf8(*this, message, -1, &str);
+  if (status != napi_ok) throw NewError();
+
+  napi_value error;
+  status = napi_create_error(*this, str, &error);
+  if (status != napi_ok) throw NewError();
+
+  return Error(*this, error);
+}
+
+inline Buffer Env::NewBuffer(char* data, size_t size) {
+  napi_value value;
+  napi_status status = napi_buffer_new(*this, data, size, &value);
+  if (status != napi_ok) throw NewError();
+  return Buffer(*this, value);
+}
+
+inline Buffer Env::CopyBuffer(const char* data, size_t size) {
+  napi_value value;
+  napi_status status = napi_buffer_copy(*this, data, size, &value);
+  if (status != napi_ok) throw NewError();
+  return Buffer(*this, value);
+}
+
+inline Number Env::NewNumber(double val) {
+  napi_value value;
+  napi_status status = napi_create_number(_env, val, &value);
+  if (status != napi_ok) throw NewError();
+  return Number(_env, value);
+}
+
+inline Boolean Env::NewBoolean(bool val) {
+  napi_value value;
+  napi_status status = napi_create_boolean(_env, val, &value);
+  if (status != napi_ok) throw NewError();
+  return Boolean(_env, value);
+}
+
+inline String Env::NewStringUtf8(const char* val, int length) {
+  napi_value value;
+  napi_status status = napi_create_string_utf8(_env, val, length, &value);
+  if (status != napi_ok) throw NewError();
+  return String(_env, value);
+}
+
+inline String Env::NewStringUtf16(const char16_t* val, int length) {
+  napi_value value;
+  napi_status status = napi_create_string_utf16(_env, val, length, &value);
+  if (status != napi_ok) throw NewError();
+  return String(_env, value);
+}
+
+inline Object Env::NewObject() {
+  napi_value value;
+  napi_status status = napi_create_object(_env, &value);
+  if (status != napi_ok) throw NewError();
+  return Object(_env, value);
+}
+
+inline Array Env::NewArray() {
+  napi_value value;
+  napi_status status = napi_create_array(_env, &value);
+  if (status != napi_ok) throw NewError();
+  return Array(_env, value);
+}
+
+inline Array Env::NewArray(int length) {
+  napi_value value;
+  napi_status status = napi_create_array_with_length(_env, length, &value);
+  if (status != napi_ok) throw NewError();
+  return Array(_env, value);
+}
+
+inline Function Env::NewFunction(VoidFunctionCallback cb, const char* utf8name, void* data) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the function is destroyed
+  callbackData->voidFunctionCallback = cb;
+  callbackData->data = data;
+
+  // TODO: set the function name
+  napi_value value;
+  napi_status status = napi_create_function(
+    _env, VoidFunctionCallbackWrapper, callbackData, &value);
+  if (status != napi_ok) throw NewError();
+  return Function(_env, value);
+}
+
+inline Function Env::NewFunction(FunctionCallback cb, const char* utf8name, void* data) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the function is destroyed
+  callbackData->functionCallback = cb;
+  callbackData->data = data;
+
+  // TODO: set the function name
+  napi_value value;
+  napi_status status = napi_create_function(
+    _env, FunctionCallbackWrapper, callbackData, &value);
+  if (status != napi_ok) throw NewError();
+  return Function(_env, value);
+}
+
+inline void Env::VoidFunctionCallbackWrapper(napi_env env, napi_callback_info info) {
+  napi_value result;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    callbackData->functionCallback(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+}
+
+inline void Env::FunctionCallbackWrapper(napi_env env, napi_callback_info info) {
+  napi_value result;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    result = callbackData->functionCallback(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+
+  napi_status status = napi_set_return_value(env, info, result);
+  if (status != napi_ok) return;
+}
+
+inline bool Env::IsExceptionPending() const {
+  bool result;
+  napi_status status = napi_is_exception_pending(_env, &result);
+  if (status != napi_ok) result = false; // Checking for a pending exception shouldn't throw.
+  return result;
+}
+
+inline void Env::Throw(Value error) {
+  napi_throw(_env, error);
+  throw NewError();
+}
+
+inline void Env::ThrowError(const char* message) {
+  napi_throw_error(_env, message);
+  throw NewError();
+}
+
+inline void Env::ThrowTypeError(const char* message) {
+  napi_throw_type_error(_env, message);
+  throw NewError();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PropertyName class
+////////////////////////////////////////////////////////////////////////////////
+
+inline PropertyName::PropertyName(napi_env env, napi_propertyname name) : _env(env), _name(name) {
+}
+
+inline PropertyName::PropertyName(napi_env env, const char* utf8name) : _env(env) {
+  napi_status status = napi_property_name(env, utf8name, &_name);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline PropertyName::operator napi_propertyname() const {
+  return _name;
+}
+
+inline Env PropertyName::Env() const {
+  return Napi::Env(_env);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Value class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Value::Value() : _env(nullptr), _value(nullptr) {
+}
+
+inline Value::Value(napi_env env, napi_value value) : _env(env), _value(value) {
+}
+
+inline Value::operator napi_value() const {
+  return _value;
+}
+
+inline bool Value::operator ==(const Value& other) const {
+  return StrictEquals(other);
+}
+
+inline bool Value::operator !=(const Value& other) const {
+  return !StrictEquals(other);
+}
+
+inline bool Value::StrictEquals(const Value& other) const {
+  bool result;
+  napi_status status = napi_strict_equals(_env, *this, other, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline Persistent Value::MakePersistent() const {
+  napi_persistent persistent;
+  napi_status status = napi_create_persistent(_env, _value, &persistent);
+  if (status != napi_ok) throw Env().NewError();
+  return Persistent(_env, persistent);
+}
+
+inline Env Value::Env() const {
+  return Napi::Env(_env);
+}
+
+inline napi_valuetype Value::Type() const {
+  if (_value == nullptr) {
+    return napi_undefined;
+  }
+
+  napi_valuetype type;
+  napi_status status = napi_get_type_of_value(_env, _value, &type);
+  if (status != napi_ok) throw Env().NewError();
+  return type;
+}
+
+inline bool Value::IsUndefined() const {
+  return Type() == napi_undefined;
+}
+
+inline bool Value::IsNull() const {
+  return Type() == napi_null;
+}
+
+inline bool Value::IsBoolean() const {
+  return Type() == napi_boolean;
+}
+
+inline bool Value::IsNumber() const {
+  return Type() == napi_number;
+}
+
+inline bool Value::IsString() const {
+  return Type() == napi_string;
+}
+
+inline bool Value::IsSymbol() const {
+  return Type() == napi_symbol;
+}
+
+inline bool Value::IsArray() const {
+  if (_value == nullptr) {
+    return false;
+  }
+
+  bool result;
+  napi_status status = napi_is_array(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline bool Value::IsObject() const {
+  return Type() == napi_object;
+}
+
+inline bool Value::IsFunction() const {
+  return Type() == napi_function;
+}
+
+inline bool Value::IsBuffer() const {
+  if (_value == nullptr) {
+    return false;
+  }
+
+  bool result;
+  napi_status status = napi_buffer_has_instance(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline Boolean Value::AsBoolean() const {
+  return Boolean(_env, _value);
+}
+
+inline Number Value::AsNumber() const {
+  return Number(_env, _value);
+}
+
+inline String Value::AsString() const {
+  return String(_env, _value);
+}
+
+inline Object Value::AsObject() const {
+  return Object(_env, _value);
+}
+
+inline Array Value::AsArray() const {
+  return Array(_env, _value);
+}
+
+inline Function Value::AsFunction() const {
+  return Function(_env, _value);
+}
+
+inline Buffer Value::AsBuffer() const {
+  return Buffer(_env, _value);
+}
+
+inline Boolean Value::ToBoolean() const {
+  napi_value result;
+  napi_status status = napi_coerce_to_bool(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Boolean(_env, result);
+}
+
+inline Number Value::ToNumber() const {
+  napi_value result;
+  napi_status status = napi_coerce_to_number(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Number(_env, result);
+}
+
+inline String Value::ToString() const {
+  napi_value result;
+  napi_status status = napi_coerce_to_string(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return String(_env, result);
+}
+
+inline Object Value::ToObject() const {
+  napi_value result;
+  napi_status status = napi_coerce_to_object(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Object(_env, result);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Boolean class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Boolean::Boolean() : Napi::Value() {
+}
+
+inline Boolean::Boolean(napi_env env, napi_value value) : Napi::Value(env, value) {
+}
+
+inline Boolean::operator bool() const {
+  return Value();
+}
+
+inline bool Boolean::Value() const {
+  bool result;
+  napi_status status = napi_get_value_bool(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Number class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Number::Number() : Value() {
+}
+
+inline Number::Number(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline Number::operator int32_t() const {
+  return Int32Value();
+}
+
+inline Number::operator uint32_t() const {
+  return Uint32Value();
+}
+
+inline Number::operator int64_t() const {
+  return Int64Value();
+}
+
+inline Number::operator float() const {
+  return FloatValue();
+}
+
+inline Number::operator double() const {
+  return DoubleValue();
+}
+
+inline int32_t Number::Int32Value() const {
+  int32_t result;
+  napi_status status = napi_get_value_int32(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline uint32_t Number::Uint32Value() const {
+  uint32_t result;
+  napi_status status = napi_get_value_uint32(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline int64_t Number::Int64Value() const {
+  int64_t result;
+  napi_status status = napi_get_value_int64(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline float Number::FloatValue() const {
+  return static_cast<float>(DoubleValue());
+}
+
+inline double Number::DoubleValue() const {
+  double result;
+  napi_status status = napi_get_value_double(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// String class
+////////////////////////////////////////////////////////////////////////////////
+
+inline String::String() : Value() {
+}
+
+inline String::String(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline String::operator std::string() const {
+  return Utf8Value();
+}
+
+inline String::operator std::u16string() const {
+  return Utf16Value();
+}
+
+inline std::string String::Utf8Value() const {
+  int length;
+  napi_status status = napi_get_value_string_utf8_length(_env, _value, &length);
+  if (status != napi_ok) throw Env().NewError();
+
+  std::string value;
+  value.resize(length);
+  status = napi_get_value_string_utf8(_env, _value, &value[0], value.capacity(), nullptr);
+  if (status != napi_ok) throw Env().NewError();
+  return value;
+}
+
+inline std::u16string String::Utf16Value() const {
+  int length;
+  napi_status status = napi_get_value_string_utf16_length(_env, _value, &length);
+  if (status != napi_ok) throw Env().NewError();
+
+  std::u16string value;
+  value.resize(length);
+  status = napi_get_value_string_utf16(_env, _value, &value[0], value.capacity(), nullptr);
+  if (status != napi_ok) throw Env().NewError();
+  return value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Object class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Object::Object() : Value() {
+}
+
+inline Object::Object(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline Value Object::operator [](const char* name) const {
+  return Get(name);
+}
+
+inline Value Object::Get(const PropertyName& name) const {
+  napi_value result;
+  napi_status status = napi_get_property(_env, _value, name, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Value(_env, result);
+}
+
+inline Value Object::Get(const char* utf8name) const {
+  return Get(PropertyName(_env, utf8name));
+}
+
+inline void Object::Set(const PropertyName& name, const Value& value) {
+  napi_status status = napi_set_property(_env, _value, name, value);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline void Object::Set(const char* utf8name, const Value& value) {
+  Set(PropertyName(_env, utf8name), value);
+}
+
+inline void Object::Set(const char* utf8name, const char* utf8value) {
+  Set(PropertyName(_env, utf8name), Env().NewStringUtf8(utf8value));
+}
+
+inline void Object::Set(const char* utf8name, bool boolValue) {
+  Set(PropertyName(_env, utf8name), Env().NewBoolean(boolValue));
+}
+
+inline void Object::Set(const char* utf8name, double numberValue) {
+  Set(PropertyName(_env, utf8name), Env().NewNumber(numberValue));
+}
+
+inline void Object::DefineProperty(const PropertyDescriptor& property) {
+  napi_status status = napi_define_properties(_env, _value, 1,
+    reinterpret_cast<const napi_property_descriptor*>(&property));
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline void Object::DefineProperties(const std::vector<PropertyDescriptor>& properties) {
+  napi_status status = napi_define_properties(_env, _value, properties.size(),
+    reinterpret_cast<const napi_property_descriptor*>(properties.data()));
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline bool Object::InstanceOf(const Value& constructor) const {
+  bool result;
+  napi_status status = napi_instanceof(_env, _value, constructor, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+template<typename T>
+inline T* Object::Unwrap() const {
+  T* unwrapped;
+  napi_status status = napi_unwrap(_env, _value, reinterpret_cast<void**>(&unwrapped));
+  if (status != napi_ok) throw Env().NewError();
+  return unwrapped;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Array class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Array::Array() : Value() {
+}
+
+inline Array::Array(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline Value Array::operator [](uint32_t index) const {
+  return Get(index);
+}
+
+inline uint32_t Array::Length() const {
+  uint32_t result;
+  napi_status status = napi_get_array_length(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline bool Array::Has(uint32_t index) const {
+  bool result;
+  napi_status status = napi_has_element(_env, _value, index, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline Value Array::Get(uint32_t index) const {
+  napi_value value;
+  napi_status status = napi_get_element(_env, _value, index, &value);
+  if (status != napi_ok) throw Env().NewError();
+  return Value(_env, value);
+}
+
+inline void Array::Set(uint32_t index, const Value& value) {
+  napi_status status = napi_set_element(_env, _value, index, value);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline void Array::Set(uint32_t index, const char* utf8value) {
+  Set(index, Env().NewStringUtf8(utf8value));
+}
+
+inline void Array::Set(uint32_t index, bool boolValue) {
+  Set(index, Env().NewBoolean(boolValue));
+}
+
+inline void Array::Set(uint32_t index, double numberValue) {
+  Set(index, Env().NewNumber(numberValue));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Function class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Function::Function() : Value() {
+}
+
+inline Function::Function(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline Value Function::operator ()(const std::vector<Value>& args) const {
+  return Call(args);
+}
+
+inline Value Function::operator ()(Object& recv, const std::vector<Value>& args) const {
+  return Call(recv, args);
+}
+
+inline Value Function::Call(const std::vector<Value>& args) const {
+  Object global = Env().Global();
+  return Call(global, args);
+}
+
+inline Value Function::Call(Object& recv, const std::vector<Value>& args) const {
+  // Convert args from Value to napi_value.
+  std::vector<napi_value> argv;
+  argv.reserve(args.size());
+  for (size_t i = 0; i < args.size(); i++) {
+    argv.push_back(args[i]);
+  }
+
+  napi_value result;
+  napi_status status = napi_call_function(_env, recv, _value, argv.size(), argv.data(), &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Value(_env, result);
+}
+
+inline Value Function::MakeCallback(const std::vector<Value>& args) const {
+  Value global = Env().Global();
+  return MakeCallback(global, args);
+}
+
+inline Value Function::MakeCallback(
+  Value& recv, const std::vector<Value>& args) const {
+  // Convert args from Value to napi_value.
+  std::vector<napi_value> argv;
+  argv.reserve(args.size());
+  for (size_t i = 0; i < args.size(); i++) {
+    argv.push_back(args[i]);
+  }
+
+  napi_value result;
+  napi_status status = napi_make_callback(_env, recv, _value, argv.size(), argv.data(), &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Value(_env, result);
+}
+
+inline Object Function::New(const std::vector<Value>& args) {
+  // Convert args from Value to napi_value.
+  std::vector<napi_value> argv;
+  argv.reserve(args.size());
+  for (size_t i = 0; i < args.size(); i++) {
+    argv.push_back(args[i]);
+  }
+
+  napi_value result;
+  napi_status status = napi_new_instance(_env, _value, argv.size(), argv.data(), &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Object(_env, result);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Buffer class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Buffer::Buffer() : Value() {
+}
+
+inline Buffer::Buffer(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline size_t Buffer::Length() const {
+  size_t result;
+  napi_status status = napi_buffer_length(_env, _value, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return result;
+}
+
+inline char* Buffer::Data() const {
+  char* data;
+  napi_status status = napi_buffer_data(_env, _value, &data);
+  if (status != napi_ok) throw Env().NewError();
+  return data;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Error class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Error::Error() : Value(), _message(nullptr) {
+}
+
+inline Error::Error(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline std::string Error::Message() const {
+  if (_message.size() == 0 && _env != nullptr) {
+    try {
+      const_cast<Error*>(this)->_message = this->AsObject()["message"].AsString();
+    }
+    catch (const Error&) {
+    }
+  }
+  return _message;
+}
+
+inline void Error::ThrowAsJavaScriptException() const {
+  if (_value != nullptr) {
+    napi_throw(_env, _value);
+  }
+}
+
+inline const char* Error::what() const {
+  return Message().c_str();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Persistent class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Persistent::Persistent() : _env(nullptr), _persistent(nullptr) {
+}
+
+inline Persistent::Persistent(napi_env env, napi_persistent persistent)
+  : _env(env), _persistent(persistent) {
+}
+
+inline Persistent::~Persistent() {
+  if (_persistent != nullptr) {
+    napi_release_persistent(_env, _persistent);
+    _persistent = nullptr;
+  }
+}
+
+inline Persistent::Persistent(Persistent&& other) {
+  _env = other._env;
+  _persistent = other._persistent;
+  other._env = nullptr;
+  other._persistent = nullptr;
+}
+
+inline Persistent& Persistent::operator =(Persistent&& other) {
+  _env = other._env;
+  _persistent = other._persistent;
+  other._env = nullptr;
+  other._persistent = nullptr;
+  return *this;
+}
+
+inline Persistent::operator napi_persistent() const {
+  return _persistent;
+}
+
+inline Env Persistent::Env() const {
+  return Napi::Env(_env);
+}
+
+inline Value Persistent::Value() const {
+  if (_persistent == nullptr) {
+    return Napi::Value(_env, nullptr);
+  }
+
+  napi_value value;
+  napi_status status = napi_get_persistent_value(_env, _persistent, &value);
+  if (status != napi_ok) throw Env().NewError();
+  return Napi::Value(_env, value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CallbackInfo class
+////////////////////////////////////////////////////////////////////////////////
+
+inline CallbackInfo::CallbackInfo(napi_env env, napi_callback_info info)
+    : _env(env), _this(nullptr), _args(), _data(nullptr) {
+  napi_status status = napi_get_cb_this(env, info, &_this);
+  if (status != napi_ok) throw Env().NewError();
+
+  int argc;
+  status = napi_get_cb_args_length(env, info, &argc);
+  if (status != napi_ok) throw Env().NewError();
+
+  if (argc > 0) {
+    _args.resize(argc);
+    status = napi_get_cb_args(env, info, _args.data(), argc);
+    if (status != napi_ok) throw Env().NewError();
+  }
+
+  status = napi_get_cb_data(env, info, reinterpret_cast<void**>(&_data));
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline Env CallbackInfo::Env() const {
+  return Napi::Env(_env);
+}
+
+inline int CallbackInfo::Length() const {
+  return _args.size();
+}
+
+inline const Value CallbackInfo::operator[](int index) const {
+  return static_cast<size_t>(index) < _args.size() ?
+    Value(_env, _args[index]) : Env().Undefined();
+}
+
+inline Object CallbackInfo::This() const {
+  if (_this == nullptr) {
+    return Env().Global();
+  }
+  return Object(_env, _this);
+}
+
+inline void* CallbackInfo::Data() const {
+  return _data;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ObjectWrap<T> class
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+inline ObjectWrap<T>::ObjectWrap() {
+}
+
+template <typename T>
+inline Object ObjectWrap<T>::Wrapper() const {
+  return _wrapper.Value().AsObject();
+}
+
+template <typename T>
+inline Function ObjectWrap<T>::DefineClass(
+    Env env,
+    const char* utf8name,
+    ConstructorCallback constructor,
+    const std::vector<ClassPropertyDescriptor<T>>& properties,
+    void* data = nullptr) {
+  std::vector<napi_property_descriptor> staticProperties;
+  staticProperties.reserve(properties.size());
+  std::vector<napi_property_descriptor> instanceProperties;
+  instanceProperties.reserve(properties.size());
+
+  for (auto i = properties.begin(); i != properties.end(); i++) {
+    const napi_property_descriptor& p = *i;
+    if ((p.attributes & napi_instance_property) == 0) {
+      staticProperties.push_back(p);
+    }
+    else {
+      instanceProperties.push_back(p);
+      napi_property_descriptor& q = instanceProperties.back();
+      q.attributes = static_cast<napi_property_attributes>(
+        q.attributes & ~napi_instance_property);
+    }
+  }
+
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->constructorCallback = constructor;
+  callbackData->data = data;
+
+  napi_value value;
+  napi_status status = napi_define_class(env, utf8name,
+    T::ConstructorCallbackWrapper, callbackData, instanceProperties.size(),
+    instanceProperties.data(), &value);
+  if (status != napi_ok) throw env.NewError();
+
+  status = napi_define_properties(env, value, staticProperties.size(),
+    reinterpret_cast<const napi_property_descriptor*>(staticProperties.data()));
+  if (status != napi_ok) throw env.NewError();
+
+  return Function(env, value);
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
+    const char* utf8name,
+    StaticVoidMethodCallback method,
+    napi_property_attributes attributes = napi_default,
+    void* data = nullptr) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->staticVoidMethodCallback = method;
+  callbackData->data = data;
+
+  napi_property_descriptor desc = { utf8name };
+  desc.method = T::StaticVoidMethodCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = attributes;
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
+    const char* utf8name,
+    StaticMethodCallback method,
+    napi_property_attributes attributes = napi_default,
+    void* data = nullptr) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->staticMethodCallback = method;
+  callbackData->data = data;
+
+  napi_property_descriptor desc = { utf8name };
+  desc.method = T::StaticMethodCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = attributes;
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
+    const char* utf8name,
+    StaticGetterCallback getter,
+    StaticSetterCallback setter,
+    napi_property_attributes attributes = napi_default,
+    void* data = nullptr) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->staticGetterCallback = getter;
+  callbackData->staticSetterCallback = setter;
+  callbackData->data = data;
+
+  napi_property_descriptor desc = { utf8name };
+  desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
+  desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
+  desc.data = callbackData;
+  desc.attributes = attributes;
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceMethod(
+    const char* utf8name,
+    InstanceVoidMethodCallback method,
+    napi_property_attributes attributes = napi_default,
+    void* data = nullptr) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->instanceVoidMethodCallback = method;
+  callbackData->data = data;
+
+  napi_property_descriptor desc = { utf8name };
+  desc.method = T::InstanceVoidMethodCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = static_cast<napi_property_attributes>(
+    attributes | napi_instance_property);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceMethod(
+    const char* utf8name,
+    InstanceMethodCallback method,
+    napi_property_attributes attributes = napi_default,
+    void* data = nullptr) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->instanceMethodCallback = method;
+  callbackData->data = data;
+
+  napi_property_descriptor desc = { utf8name };
+  desc.method = T::InstanceMethodCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = static_cast<napi_property_attributes>(
+    attributes | napi_instance_property);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceAccessor(
+    const char* utf8name,
+    InstanceGetterCallback getter,
+    InstanceSetterCallback setter,
+    napi_property_attributes attributes = napi_default,
+    void* data = nullptr) {
+  CallbackData* callbackData = new CallbackData({}); // TODO: Delete when the class is destroyed
+  callbackData->instanceGetterCallback = getter;
+  callbackData->instanceSetterCallback = setter;
+  callbackData->data = data;
+
+  napi_property_descriptor desc = { utf8name };
+  desc.getter = T::InstanceGetterCallbackWrapper;
+  desc.setter = T::InstanceSetterCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = static_cast<napi_property_attributes>(
+    attributes | napi_instance_property);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(const char* utf8name,
+    Value value, napi_property_attributes attributes = napi_default) {
+  napi_property_descriptor desc = { utf8name };
+  desc.value = value;
+  desc.attributes = attributes;
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
+    const char* utf8name,
+    Value value,
+    napi_property_attributes attributes = napi_default) {
+  napi_property_descriptor desc = { utf8name };
+  desc.value = value;
+  desc.attributes = static_cast<napi_property_attributes>(
+    attributes | napi_instance_property);
+  return desc;
+}
+
+template <typename T>
+inline void ObjectWrap<T>::ConstructorCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  bool isConstructCall;
+  napi_status status = napi_is_construct_call(env, info, &isConstructCall);
+  if (status != napi_ok) return;
+
+  if (!isConstructCall) {
+    napi_throw_type_error(env, "Class constructors cannot be invoked without 'new'");
+    return;
+  }
+
+  T* instance;
+  napi_value wrapper;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    instance = callbackData->constructorCallback(callbackInfo);
+    instance->_wrapper = callbackInfo.This().MakePersistent();
+    wrapper = callbackInfo.This();
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+
+  status = napi_wrap(env, wrapper, instance, nullptr, nullptr); // TODO: Destructor?
+  if (status != napi_ok) return;
+
+  status = napi_set_return_value(env, info, wrapper);
+  if (status != napi_ok) return;
+}
+
+template <typename T>
+inline void ObjectWrap<T>::StaticVoidMethodCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    callbackData->staticVoidMethodCallback(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+}
+
+template <typename T>
+inline void ObjectWrap<T>::StaticMethodCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  napi_value result;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    result = callbackData->staticMethodCallback(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+
+  napi_status status = napi_set_return_value(env, info, result);
+  if (status != napi_ok) return;
+}
+
+template <typename T>
+inline void ObjectWrap<T>::StaticGetterCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  napi_value result;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    result = callbackData->staticGetterCallback(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+
+  napi_status status = napi_set_return_value(env, info, result);
+  if (status != napi_ok) return;
+}
+
+template <typename T>
+inline void ObjectWrap<T>::StaticSetterCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    callbackData->staticSetterCallback(callbackInfo, callbackInfo[0]);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+}
+
+template <typename T>
+inline void ObjectWrap<T>::InstanceVoidMethodCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    T* instance = callbackInfo.This().Unwrap<T>();
+    auto cb = callbackData->instanceVoidMethodCallback;
+    (instance->*cb)(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+}
+
+template <typename T>
+inline void ObjectWrap<T>::InstanceMethodCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  napi_value result;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    T* instance = callbackInfo.This().Unwrap<T>();
+    auto cb = callbackData->instanceMethodCallback;
+    result = (instance->*cb)(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+
+  napi_status status = napi_set_return_value(env, info, result);
+  if (status != napi_ok) return;
+}
+
+template <typename T>
+inline void ObjectWrap<T>::InstanceGetterCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  napi_value result;
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    T* instance = callbackInfo.This().Unwrap<T>();
+    auto cb = callbackData->instanceGetterCallback;
+    result = (instance->*cb)(callbackInfo);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+
+  napi_status status = napi_set_return_value(env, info, result);
+  if (status != napi_ok) return;
+}
+
+template <typename T>
+inline void ObjectWrap<T>::InstanceSetterCallbackWrapper(
+    napi_env env,
+    napi_callback_info info) {
+  try {
+    CallbackInfo callbackInfo(env, info);
+    CallbackData* callbackData = reinterpret_cast<CallbackData*>(callbackInfo.Data());
+    T* instance = callbackInfo.This().Unwrap<T>();
+    auto cb = callbackData->instanceSetterCallback;
+    (instance->*cb)(callbackInfo, callbackInfo[0]);
+  }
+  catch (const Error& e) {
+    if (!Env(env).IsExceptionPending()) {
+      e.ThrowAsJavaScriptException();
+    }
+    return;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// HandleScope class
+////////////////////////////////////////////////////////////////////////////////
+
+inline HandleScope::HandleScope(napi_env env, napi_handle_scope scope)
+    : _env(env), _scope(scope) {
+}
+
+inline HandleScope::HandleScope(Napi::Env env) : _env(env) {
+  napi_status status = napi_open_handle_scope(_env, &_scope);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline HandleScope::~HandleScope() {
+  napi_close_handle_scope(_env, _scope);
+}
+
+inline HandleScope::operator napi_handle_scope() const {
+  return _scope;
+}
+
+inline Env HandleScope::Env() const {
+  return Napi::Env(_env);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// EscapableHandleScope class
+////////////////////////////////////////////////////////////////////////////////
+
+inline EscapableHandleScope::EscapableHandleScope(
+  napi_env env, napi_escapable_handle_scope scope) : _env(env), _scope(scope) {
+}
+
+inline EscapableHandleScope::EscapableHandleScope(Napi::Env env) : _env(env) {
+  napi_status status = napi_open_escapable_handle_scope(_env, &_scope);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline EscapableHandleScope::~EscapableHandleScope() {
+  napi_close_escapable_handle_scope(_env, _scope);
+}
+
+inline EscapableHandleScope::operator napi_escapable_handle_scope() const {
+  return _scope;
+}
+
+inline Env EscapableHandleScope::Env() const {
+  return Napi::Env(_env);
+}
+
+inline Value EscapableHandleScope::Escape(Value escapee) {
+  napi_value result;
+  napi_status status = napi_escape_handle(_env, _scope, escapee, &result);
+  if (status != napi_ok) throw Env().NewError();
+  return Value(_env, result);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Callback class
+////////////////////////////////////////////////////////////////////////////////
+
+inline Callback::Callback() : _env(nullptr), _handle(nullptr) {
+}
+
+inline Callback::Callback(napi_env env, napi_value fn) : _env(env), _handle(nullptr) {
+  HandleScope scope = HandleScope(Env());
+
+  napi_value obj;
+  napi_status status = napi_create_object(env, &obj);
+  if (status != napi_ok) throw Env().NewError();
+
+  status = napi_set_element(env, obj, _kCallbackIndex, fn);
+  if (status != napi_ok) throw Env().NewError();
+
+  status = napi_create_persistent(env, obj, &_handle);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline Callback::Callback(Function fn) : Callback(fn.Env(), fn) {
+}
+
+inline Callback::~Callback() {
+  if (_handle == nullptr) {
+    return;
+  }
+
+  napi_release_persistent(_env, _handle);
+}
+
+inline bool Callback::operator ==(const Callback &other) const {
+  HandleScope scope = HandleScope(Env());
+  return this->GetFunction().StrictEquals(other.GetFunction());
+}
+
+inline bool Callback::operator !=(const Callback &other) const {
+  return !this->operator==(other);
+}
+
+inline Value Callback::operator *() const {
+  return GetFunction();
+}
+
+inline Value Callback::operator ()(Object& recv, const std::vector<Value>& args) const {
+  return Call(recv, args);
+}
+
+inline Value Callback::operator ()(const std::vector<Value>& args) const {
+  return Call(args);
+}
+
+inline Env Callback::Env() const {
+  return Napi::Env(_env);
+}
+
+inline bool Callback::IsEmpty() const {
+  return GetFunction().Type() == napi_undefined;
+}
+
+inline Value Callback::GetFunction() const {
+  EscapableHandleScope scope = EscapableHandleScope(Env());
+
+  napi_value obj;
+  napi_status status = napi_get_persistent_value(_env, _handle, &obj);
+  if (status != napi_ok) throw Env().NewError();
+
+  napi_value fn;
+  status = napi_get_element(_env, obj, _kCallbackIndex, &fn);
+  if (status != napi_ok) throw Env().NewError();
+
+  return scope.Escape(Value(_env, fn));
+}
+
+inline void Callback::SetFunction(const Value& fn) {
+  EscapableHandleScope scope = EscapableHandleScope(Env());
+
+  napi_value obj;
+  napi_status status = napi_get_persistent_value(_env, _handle, &obj);
+  if (status != napi_ok) throw Env().NewError();
+
+  status = napi_set_element(_env, obj, _kCallbackIndex, fn);
+  if (status != napi_ok) throw Env().NewError();
+}
+
+inline Value Callback::Call(const std::vector<Value>& args) const {
+  Object global = Env().Global();
+  return Call(global, args);
+}
+
+inline Value Callback::Call(Object& recv, const std::vector<Value>& args) const {
+  EscapableHandleScope scope = EscapableHandleScope(Env());
+
+  // Convert args from Value to napi_value.
+  std::vector<napi_value> argv;
+  argv.reserve(args.size());
+  for (size_t i = 0; i < args.size(); i++) {
+    argv.push_back(args[i]);
+  }
+
+  napi_value cb;
+  napi_status status = napi_make_callback(
+    _env,
+    recv,
+    GetFunction(),
+    argv.size(),
+    argv.data(),
+    &cb);
+  if (status != napi_ok) throw Env().NewError();
+
+  return scope.Escape(Value(_env, cb));
+}
+
+} // namespace Napi
+
+#endif // SRC_NAPI_INL_H_

--- a/src/napi.h
+++ b/src/napi.h
@@ -1,0 +1,558 @@
+﻿#ifndef SRC_NODE_API_HELPERS_H_
+#define SRC_NAPI_H_
+
+////////////////////////////////////////////////////////////////////////////////
+// NAPI C++ Wrapper Classes
+//
+// These classes wrap the "NAPI" ABI-stable C APIs for Node.js, providing a
+// C++ object model and C++ exception-handling semantics with low overhead.
+// The wrappers are all header-only so that they do not affect the ABI.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "node_jsvmapi.h"
+#include "node_asyncapi.h"
+#include <string>
+#include <vector>
+
+namespace Napi {
+
+  class Value;
+  class Boolean;
+  class Number;
+  class String;
+  class Object;
+  class Array;
+  class Function;
+  class Buffer;
+  class Error;
+  class Persistent;
+  class PropertyDescriptor;
+  class CallbackInfo;
+
+  // Functions exposed to JavaScript must conform to one these callback signatures.
+  // (See ObjectWrap<T> for callbacks used when wrapping entire classes.)
+  typedef void (*VoidFunctionCallback)(const CallbackInfo& info);
+  typedef Value (*FunctionCallback)(const CallbackInfo& info);
+
+  /*
+   * Environment for NAPI operations. (In V8 this corresponds to an Isolate.)
+   */
+  class Env {
+  public:
+    explicit Env(napi_env env);
+
+    operator napi_env() const;
+
+    static Env Current();
+
+    Object Global() const;
+    Value Undefined() const;
+    Value Null() const;
+
+    Error NewError();
+    Error NewError(const char* message);
+    Error NewTypeError(const char* message);
+    Buffer NewBuffer(char* data, size_t size);
+    Buffer CopyBuffer(const char* data, size_t size);
+    Number NewNumber(double val);
+    Boolean NewBoolean(bool val);
+    String NewStringUtf8(const char* val, int length = -1);
+    String NewStringUtf16(const char16_t* val, int length = -1);
+    Array NewArray();
+    Array NewArray(int length);
+    Object NewObject();
+    Function NewFunction(VoidFunctionCallback cb,
+                         const char* utf8name = nullptr,
+                         void* data = nullptr);
+    Function NewFunction(FunctionCallback cb,
+                         const char* utf8name = nullptr,
+                         void* data = nullptr);
+
+    bool IsExceptionPending() const;
+    void Throw(Value error);
+    void ThrowError(const char* message);
+    void ThrowTypeError(const char* message);
+
+  private:
+    napi_env _env;
+
+    static void VoidFunctionCallbackWrapper(napi_env env, napi_callback_info info);
+    static void FunctionCallbackWrapper(napi_env env, napi_callback_info info);
+
+    typedef struct {
+      union {
+        VoidFunctionCallback voidFunctionCallback;
+        FunctionCallback functionCallback;
+      };
+      void* data;
+    } CallbackData;
+  };
+
+  class PropertyName {
+  public:
+    PropertyName(napi_env env, napi_propertyname name);
+    PropertyName(napi_env env, const char* utf8name);
+
+    operator napi_propertyname() const;
+
+    Env Env() const;
+
+  private:
+    napi_env _env;
+    napi_propertyname _name;
+  };
+
+  /*
+   * Represents a JavaScript value of unknown type.
+   *
+   * For type-specific operations, convert to one of the Value subclasses using a
+   * To* or As* method. The To* methods do type coercion; the As* methods do not.
+   */
+  class Value {
+  public:
+    Value();
+    Value(napi_env env, napi_value value);
+
+    operator napi_value() const;
+    bool operator ==(const Value& other) const;
+    bool operator !=(const Value& other) const;
+    bool StrictEquals(const Value& other) const;
+    Persistent MakePersistent() const;
+
+    Env Env() const;
+
+    napi_valuetype Type() const;
+    bool IsUndefined() const;
+    bool IsNull() const;
+    bool IsBoolean() const;
+    bool IsNumber() const;
+    bool IsString() const;
+    bool IsSymbol() const;
+    bool IsArray() const;
+    bool IsObject() const;
+    bool IsFunction() const;
+    bool IsBuffer() const;
+
+    Boolean AsBoolean() const;
+    Number AsNumber() const;
+    String AsString() const;
+    Object AsObject() const;
+    Array AsArray() const;
+    Function AsFunction() const;
+    Buffer AsBuffer() const;
+
+    Boolean ToBoolean() const;
+    Number ToNumber() const;
+    String ToString() const;
+    Object ToObject() const;
+
+  protected:
+    napi_env _env;
+    napi_value _value;
+  };
+
+  class Boolean : public Value {
+  public:
+    Boolean();
+    Boolean(napi_env env, napi_value value);
+    operator bool() const;
+    bool Value() const;
+  };
+
+  class Number : public Value {
+  public:
+    Number();
+    Number(napi_env env, napi_value value);
+    operator int32_t() const;
+    operator uint32_t() const;
+    operator int64_t() const;
+    operator float() const;
+    operator double() const;
+    int32_t Int32Value() const;
+    uint32_t Uint32Value() const;
+    int64_t Int64Value() const;
+    float FloatValue() const;
+    double DoubleValue() const;
+  };
+
+  class String : public Value {
+  public:
+    String();
+    String(napi_env env, napi_value value);
+    operator std::string() const;
+    operator std::u16string() const;
+    std::string Utf8Value() const;
+    std::u16string Utf16Value() const;
+  };
+
+  class Object : public Value {
+  public:
+    Object();
+    Object(napi_env env, napi_value value);
+    Value operator [](const char* name) const;
+    bool Has(const PropertyName& name) const;
+    bool Has(const char* utf8name) const;
+    Value Get(const PropertyName& name) const;
+    Value Get(const char* utf8name) const;
+    void Set(const PropertyName& name, const Value& value);
+    void Set(const char* utf8name, const Value& value);
+    void Set(const char* utf8name, const char* utf8value);
+    void Set(const char* utf8name, bool boolValue);
+    void Set(const char* utf8name, double numberValue);
+    void DefineProperty(const PropertyDescriptor& property);
+    void DefineProperties(const std::vector<PropertyDescriptor>& properties);
+    bool InstanceOf(const Value& constructor) const;
+    template<typename T> T* Unwrap() const;
+  };
+
+  class Array : public Value {
+  public:
+    Array();
+    Array(napi_env env, napi_value value);
+    Value operator [](uint32_t index) const;
+    uint32_t Length() const;
+    bool Has(uint32_t index) const;
+    Value Get(uint32_t index) const;
+    void Set(uint32_t index, const Value& value);
+    void Set(uint32_t index, const char* utf8value);
+    void Set(uint32_t index, bool boolValue);
+    void Set(uint32_t index, double numberValue);
+  };
+
+  class Function : public Value {
+  public:
+    Function();
+    Function(napi_env env, napi_value value);
+    Value operator ()(const std::vector<Value>& args) const;
+    Value operator ()(Object& recv, const std::vector<Value>& args) const;
+    Value Call(const std::vector<Value>& args) const;
+    Value Call(Object& recv, const std::vector<Value>& args) const;
+    Value MakeCallback(const std::vector<Value>& args) const;
+    Value MakeCallback(Value& recv, const std::vector<Value>& args) const;
+    Object New(const std::vector<Napi::Value>& args);
+  };
+
+  class Buffer : public Value {
+  public:
+    Buffer();
+    Buffer(napi_env env, napi_value value);
+    size_t Length() const;
+    char* Data() const;
+  };
+
+  /*
+   * The NAPI Error class wraps a JavaScript Error object in a way that enables it
+   * to traverse a C++ stack and be thrown and caught as a C++ exception.
+   *
+   * If a NAPI API call fails without executing any JavaScript code (for example due
+   * to an invalid argument), then the NAPI wrapper automatically converts and throws
+   * the error as a C++ exception of type Napi::Error.
+   *
+   * If a JavaScript function called by C++ code via NAPI throws a JavaScript exception,
+   * then the NAPI wrapper automatically converts and throws it as a C++ exception of type
+   * Napi::Error.
+   *
+   * If a C++ exception of type Napi::Error escapes from a NAPI C++ callback, then
+   * the NAPI wrapper automatically converts and throws it as a JavaScript exception.
+   *
+   * Catching a C++ exception of type Napi::Error also clears the JavaScript exception.
+   * Of course it may be then re-thrown, which restores the JavaScript exception.
+   *
+   * Example 1 - Throwing an exception:
+   *
+   *   Napi::Env env = ...
+   *   throw env.NewError("Example exception");
+   *   // Following C++ statements will not be executed.
+   *   // The exception will bubble up as a C++ exception of type Napi::Error,
+   *   // until it is either caught while still in C++, or else automatically
+   *   // re-thrown as a JavaScript exception when the callback returns to JavaScript.
+   *
+   * Example 2 - Ignoring a NAPI exception:
+   *
+   *   Napi::Function jsFunctionThatThrows = someObj.AsFunction();
+   *   jsFunctionThatThrows({ arg1, arg2 });
+   *   // Following C++ statements will not be executed.
+   *   // The exception will bubble up as a C++ exception of type Napi::Error,
+   *   // until it is either caught while still in C++, or else automatically
+   *   // re-thrown as a JavaScript exception when the callback returns to JavaScript.
+   *
+   * Example 3 - Handling a NAPI exception:
+   *
+   *   Napi::Function jsFunctionThatThrows = someObj.AsFunction();
+   *   try {
+   *      jsFunctionThatThrows({ arg1, arg2 });
+   *   }
+   *   catch (const Napi::Error& e) {
+   *     cerr << "Caught JavaScript exception: " + e.what();
+   *     // Since the exception was caught here, it will not be re-thrown as
+   *     // a JavaScript exception.
+   *   }
+   */
+  class Error : public Value, public std::exception {
+  public:
+    Error();
+    Error(napi_env env, napi_value value);
+
+    std::string Message() const;
+    void ThrowAsJavaScriptException() const;
+
+    const char* what() const override;
+
+  private:
+    std::string _message;
+  };
+
+  class Persistent {
+  public:
+    Persistent();
+    Persistent(napi_env env, napi_persistent persistent);
+    ~Persistent();
+
+    // A persistent instance can be moved but cannot be copied.
+    Persistent(Persistent&& other);
+    Persistent& operator =(Persistent&& other);
+    Persistent& operator =(Persistent&) = delete;
+    Persistent(const Persistent&) = delete;
+
+    operator napi_persistent() const;
+
+    Env Env() const;
+    Value Value() const;
+
+  private:
+    napi_env _env;
+    napi_persistent _persistent;
+  };
+
+  class CallbackInfo {
+  public:
+    CallbackInfo(napi_env env, napi_callback_info info);
+
+    Env Env() const;
+    int Length() const;
+    const Value operator [](int index) const;
+    Object This() const;
+    void* Data() const;
+
+  private:
+    napi_env _env;
+    napi_value _this;
+    std::vector<napi_value> _args;
+    void* _data;
+  };
+
+  class PropertyDescriptor {
+  public:
+    PropertyDescriptor(napi_property_descriptor desc) : _desc(desc) {}
+
+    operator napi_property_descriptor&() { return _desc; }
+    operator const napi_property_descriptor&() const { return _desc; }
+
+  private:
+    napi_property_descriptor _desc;
+  };
+
+  /*
+  * Property descriptor for use with ObjectWrap<T>::DefineClass(). This is different from
+  * the standalone PropertyDescriptor because it is specific to each ObjectWrap<T>
+  * subclass. This prevents using descriptors from a different class when defining a new class
+  * (preventing the callbacks from having incorrect `this` pointers).
+  */
+  template <typename T>
+  class ClassPropertyDescriptor {
+  public:
+    ClassPropertyDescriptor(napi_property_descriptor desc) : _desc(desc) {}
+
+    operator napi_property_descriptor&() { return _desc; }
+    operator const napi_property_descriptor&() const { return _desc; }
+
+  private:
+    napi_property_descriptor _desc;
+  };
+
+  /*
+   * Base class to be extended by C++ classes exposed to JavaScript.
+   * Each C++ class instance gets "wrapped" by a JavaScript object.
+   *
+   * At initialization time, the DefineClass() method must be used to
+   * hook up the accessor and method callbacks. It takes a list of
+   * property descriptors, which can be constructed via the various
+   * static methods on the base class.
+   *
+   * Example:
+   *
+   *   class Example: public Napi::ObjectWrap<Example> {
+   *   public:
+   *     static void Initialize(Napi::Env& env, Napi::Object& target) {
+   *       Napi::Function constructor = DefineClass(env, "Example", New, {
+   *         InstanceAccessor("value", &GetValue, &SetValue),
+   *         InstanceMethod("doSomething", &DoSomething),
+   *       });
+   *       target.Set("Example", constructor);
+   *     }
+   *
+   *     static Example* New(const Napi::CallbackInfo& info) {
+   *       return new Example();
+   *     }
+   *
+   *     Napi::Value GetValue(const Napi::CallbackInfo& info);
+   *     void SetValue(const Napi::CallbackInfo& info, const Napi::Value& value);
+   *     Napi::Value DoSomething(const Napi::CallbackInfo& info);
+   *   }
+   */
+  template <typename T>
+  class ObjectWrap {
+  public:
+    ObjectWrap();
+
+    Object Wrapper() const;
+
+    // Methods exposed to JavaScript must conform to one of these callback signatures.
+    typedef T* (*ConstructorCallback)(const CallbackInfo& info);
+    typedef void (*StaticVoidMethodCallback)(const CallbackInfo& info);
+    typedef Value (*StaticMethodCallback)(const CallbackInfo& info);
+    typedef Value (*StaticGetterCallback)(const CallbackInfo& info);
+    typedef void (*StaticSetterCallback)(const CallbackInfo& info, const Value& value);
+    typedef void (T::*InstanceVoidMethodCallback)(const CallbackInfo& info);
+    typedef Value (T::*InstanceMethodCallback)(const CallbackInfo& info);
+    typedef Value (T::*InstanceGetterCallback)(const CallbackInfo& info);
+    typedef void (T::*InstanceSetterCallback)(const CallbackInfo& info, const Value& value);
+
+    typedef ClassPropertyDescriptor<T> PropertyDescriptor;
+
+    static Function DefineClass(Env env,
+                                const char* utf8name,
+                                ConstructorCallback constructor,
+                                const std::vector<PropertyDescriptor>& properties,
+                                void* data = nullptr);
+    static PropertyDescriptor StaticMethod(const char* utf8name,
+                                           StaticVoidMethodCallback method,
+                                           napi_property_attributes attributes = napi_default,
+                                           void* data = nullptr);
+    static PropertyDescriptor StaticMethod(const char* utf8name,
+                                           StaticMethodCallback method,
+                                           napi_property_attributes attributes = napi_default,
+                                           void* data = nullptr);
+    static PropertyDescriptor StaticAccessor(const char* utf8name,
+                                             StaticGetterCallback getter,
+                                             StaticSetterCallback setter,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             InstanceVoidMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             InstanceMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceAccessor(const char* utf8name,
+                                               InstanceGetterCallback getter,
+                                               InstanceSetterCallback setter,
+                                               napi_property_attributes attributes = napi_default,
+                                               void* data = nullptr);
+    static PropertyDescriptor StaticValue(const char* utf8name,
+                                          Value value,
+                                          napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor InstanceValue(const char* utf8name,
+                                            Value value,
+                                            napi_property_attributes attributes = napi_default);
+
+  private:
+    Persistent _wrapper;
+
+    static void ConstructorCallbackWrapper(napi_env env, napi_callback_info info);
+    static void StaticVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
+    static void StaticMethodCallbackWrapper(napi_env env, napi_callback_info info);
+    static void StaticGetterCallbackWrapper(napi_env env, napi_callback_info info);
+    static void StaticSetterCallbackWrapper(napi_env env, napi_callback_info info);
+    static void InstanceVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
+    static void InstanceMethodCallbackWrapper(napi_env env, napi_callback_info info);
+    static void InstanceGetterCallbackWrapper(napi_env env, napi_callback_info info);
+    static void InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
+
+    typedef struct {
+      union {
+        ConstructorCallback constructorCallback;
+        StaticVoidMethodCallback staticVoidMethodCallback;
+        StaticMethodCallback staticMethodCallback;
+        struct {
+          StaticGetterCallback staticGetterCallback;
+          StaticSetterCallback staticSetterCallabck;
+        };
+        InstanceVoidMethodCallback instanceVoidMethodCallback;
+        InstanceMethodCallback instanceMethodCallback;
+        struct {
+          InstanceGetterCallback instanceGetterCallback;
+          InstanceSetterCallback instanceSetterCallback;
+        };
+      };
+      void* data;
+    } CallbackData;
+  };
+
+  class HandleScope {
+  public:
+    HandleScope(napi_env env, napi_handle_scope scope);
+    explicit HandleScope(Napi::Env env);
+    ~HandleScope();
+
+    operator napi_handle_scope() const;
+
+    Env Env() const;
+
+  private:
+    napi_env _env;
+    napi_handle_scope _scope;
+  };
+
+  class EscapableHandleScope {
+  public:
+    EscapableHandleScope(napi_env env, napi_escapable_handle_scope scope);
+    explicit EscapableHandleScope(Napi::Env env);
+    ~EscapableHandleScope();
+
+    operator napi_escapable_handle_scope() const;
+
+    Env Env() const;
+    Value Escape(Value escapee);
+
+  private:
+    napi_env _env;
+    napi_escapable_handle_scope _scope;
+  };
+
+  class Callback {
+  public:
+    Callback();
+    Callback(napi_env env, napi_value fn);
+    explicit Callback(Function fn);
+    ~Callback();
+
+    bool operator ==(const Callback &other) const;
+    bool operator !=(const Callback &other) const;
+
+    Value operator *() const;
+    Value operator ()(Object& recv, const std::vector<Value>& args) const;
+    Value operator ()(const std::vector<Value>& args) const;
+
+    Env Env() const;
+    bool IsEmpty() const;
+    Value GetFunction() const;
+    void SetFunction(const Value& fn);
+
+    Value Call(const std::vector<Value>& args) const;
+    Value Call(Object& recv, const std::vector<Value>& args) const;
+
+  private:
+    napi_env _env;
+    napi_persistent _handle;
+    static const uint32_t _kCallbackIndex = 0;
+  };
+
+} // namespace Napi
+
+// Inline implementations of all the above class methods are included here.
+#include "napi-inl.h"
+
+#endif // SRC_NAPI_H_

--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -138,7 +138,7 @@ namespace Napi {
       HandleScope scope(env);
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &handle);
+      napi_create_reference(env, obj, 1, &handle);
     }
 
     explicit Callback(napi_value fn) {
@@ -147,7 +147,7 @@ namespace Napi {
       HandleScope scope(env);
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &handle);
+      napi_create_reference(env, obj, 1, &handle);
       SetFunction(fn);
     }
 
@@ -158,7 +158,7 @@ namespace Napi {
 
       napi_env env;
       napi_get_current_env(&env);
-      napi_release_persistent(env, handle);
+      napi_delete_reference(env, handle);
     }
 
     bool operator==(const Callback &other) const {
@@ -167,9 +167,9 @@ namespace Napi {
       napi_get_current_env(&env);
 
       napi_value ha;
-      napi_get_persistent_value(env, handle, &ha);
+      napi_get_reference_value(env, handle, &ha);
       napi_value hb;
-      napi_get_persistent_value(env, other.handle, &hb);
+      napi_get_reference_value(env, other.handle, &hb);
 
       napi_value a;
       napi_get_element(env, ha, kCallbackIndex, &a);
@@ -206,7 +206,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_set_element(env, h, kCallbackIndex, fn);
     }
 
@@ -215,7 +215,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
       return scope.Escape(fn);
@@ -226,7 +226,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
       napi_valuetype valuetype;
@@ -252,7 +252,7 @@ namespace Napi {
 
    private:
     NAPI_DISALLOW_ASSIGN_COPY_MOVE(Callback)
-    napi_persistent handle;
+    napi_ref handle;
     static const uint32_t kCallbackIndex = 0;
 
     napi_value Call_(napi_value target,
@@ -263,7 +263,7 @@ namespace Napi {
       napi_get_current_env(&env);
 
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
 
@@ -293,7 +293,7 @@ namespace Napi {
       HandleScope scope;
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &persistentHandle);
+      napi_create_reference(env, obj, 1, &persistentHandle);
     }
 
     virtual ~AsyncWorker() {
@@ -302,7 +302,7 @@ namespace Napi {
       if (persistentHandle != NULL) {
         napi_env env;
         napi_get_current_env(&env);
-        napi_release_persistent(env, persistentHandle);
+        napi_delete_reference(env, persistentHandle);
         persistentHandle = NULL;
       }
       delete callback;
@@ -330,7 +330,7 @@ namespace Napi {
       napi_propertyname pnKey;
       napi_property_name(env, key, &pnKey);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_property(env, h, pnKey, value);
     }
 
@@ -340,7 +340,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_property(env, h, key, value);
     }
 
@@ -350,7 +350,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_element(env, h, index, value);
     }
 
@@ -361,7 +361,7 @@ namespace Napi {
       napi_propertyname pnKey;
       napi_property_name(env, key, &pnKey);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_property(env, h, pnKey, &v);
       return scope.Escape(v);
@@ -373,7 +373,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_property(env, h, key, &v);
       return scope.Escape(v);
@@ -384,7 +384,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_element(env, h, index, &v);
       return scope.Escape(v);
@@ -414,7 +414,7 @@ namespace Napi {
     }
 
    protected:
-    napi_persistent persistentHandle;
+    napi_ref persistentHandle;
     Callback *callback;
 
     virtual void HandleOKCallback() {

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -131,28 +131,78 @@ namespace v8impl {
     return u.f;
   }
 
-  static napi_persistent JsPersistentFromV8PersistentValue(
-                                             v8::Persistent<v8::Value> *per) {
-    return (napi_persistent) per;
-  }
+  // Wrapper around v8::Persistent that implements reference counting.
+  class Reference {
+  public:
+    Reference(v8::Isolate* isolate,
+              v8::Local<v8::Value> value,
+              int initialRefcount,
+              bool deleteSelf,
+              napi_finalize finalizeCallback = nullptr,
+              void* finalizeData = nullptr)
+      : _isolate(isolate),
+        _persistent(isolate, value),
+        _refcount(initialRefcount),
+        _deleteSelf(deleteSelf),
+        _finalizeCallback(finalizeCallback),
+        _finalizeData(finalizeData) {
+      if (initialRefcount == 0) {
+        _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        _persistent.MarkIndependent();
+      }
+    }
 
-  static v8::Persistent<v8::Value>* V8PersistentValueFromJsPersistentValue(
-                                                        napi_persistent per) {
-    return (v8::Persistent<v8::Value>*) per;
-  }
+    ~Reference() {
+      _persistent.Reset();
+    }
 
-  static napi_weakref JsWeakRefFromV8PersistentValue(
-                                             v8::Persistent<v8::Value> *per) {
-    return (napi_weakref) per;
-  }
+    int AddRef() {
+      if (++_refcount == 1) {
+        _persistent.ClearWeak();
+      }
 
-  static v8::Persistent<v8::Value>* V8PersistentValueFromJsWeakRefValue(
-                                                           napi_weakref per) {
-    return (v8::Persistent<v8::Value>*) per;
-  }
+      return _refcount;
+    }
 
-  static void WeakRefCallback(const v8::WeakCallbackInfo<int>& data) {
-  }
+    int Release() {
+      if (--_refcount == 0) {
+        _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        _persistent.MarkIndependent();
+      }
+
+      return _refcount;
+    }
+
+    v8::Local<v8::Value> Get() {
+      if (_persistent.IsEmpty()) {
+        return v8::Local<v8::Value>();
+      }
+      else {
+        return _persistent.Get(_isolate);
+      }
+    }
+
+  private:
+    static void FinalizeCallback(const v8::WeakCallbackInfo<Reference>& data) {
+      Reference* reference = data.GetParameter();
+      reference->_persistent.Reset();
+
+      if (reference->_finalizeCallback != nullptr) {
+        reference->_finalizeCallback(reference->_finalizeData);
+      }
+
+      if (reference->_deleteSelf) {
+        delete reference;
+      }
+    }
+
+    v8::Isolate* _isolate;
+    v8::Persistent<v8::Value> _persistent;
+    int _refcount;
+    bool _deleteSelf;
+    napi_finalize _finalizeCallback;
+    void* _finalizeData;
+  };
 
   class TryCatch: public v8::TryCatch {
     public:
@@ -361,36 +411,6 @@ namespace v8impl {
 
     private:
       const v8::Local<v8::Value>& _value;
-  };
-
-  class ObjectWrapWrapper: public node::ObjectWrap {
-    public:
-      ObjectWrapWrapper(v8::Local<v8::Object> jsObject, void* nativeObj,
-                        napi_destruct destructor) {
-        _destructor = destructor;
-        _nativeObj = nativeObj;
-        Wrap(jsObject);
-      }
-
-      void* getValue() {
-        return _nativeObj;
-      }
-
-      static void* Unwrap(v8::Local<v8::Object> jsObject) {
-        ObjectWrapWrapper* wrapper =
-            ObjectWrap::Unwrap<ObjectWrapWrapper>(jsObject);
-        return wrapper->getValue();
-      }
-
-      virtual ~ObjectWrapWrapper() {
-        if (_destructor != nullptr) {
-          _destructor(_nativeObj);
-        }
-      }
-
-    private:
-      napi_destruct _destructor;
-      void* _nativeObj;
   };
 
   // Creates an object to be made available to the static function callback
@@ -1153,6 +1173,8 @@ napi_status napi_get_type_of_value(napi_env e, napi_value vv, napi_valuetype* re
     *result = napi_symbol;
   } else if (v->IsNull()) {
     *result = napi_null;
+  } else if (v->IsExternal()) {
+    *result = napi_external;
   } else {
     *result = napi_object;   // Is this correct?
   }
@@ -1569,122 +1591,153 @@ napi_status napi_coerce_to_string(napi_env e, napi_value v, napi_value* result) 
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
-                      napi_destruct destructor, napi_weakref* handle) {
+napi_status napi_wrap(napi_env e,
+                      napi_value jsObject,
+                      void* nativeObj,
+                      napi_finalize finalize_cb,
+                      napi_ref* result) {
   NAPI_PREAMBLE(e);
+  CHECK_ARG(jsObject);
+  CHECK_ARG(result);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Object> obj;
-  CHECK_TO_OBJECT(context, obj, jsObject);
 
-  v8impl::ObjectWrapWrapper* wrap =
-      new v8impl::ObjectWrapWrapper(obj, nativeObj, destructor);
+  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
+  assert(obj->InternalFieldCount() > 0);
+  obj->SetAlignedPointerInInternalField(0, nativeObj);
 
-  if (handle)
-  {
-    return napi_create_weakref(
-      e,
-      v8impl::JsValueFromV8LocalValue(wrap->handle()),
-      handle);
-  }
+  v8impl::Reference* reference = new v8impl::Reference(
+    isolate, obj, 0, false, finalize_cb, nativeObj);
+  *result = reinterpret_cast<napi_ref>(reference);
 
-  // TODO: Is the handle parameter really optional?
-  //       Why would anyone want to construct an object wrap and immediately lose it?
   return GET_RETURN_STATUS();
 }
 
 napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result) {
   NAPI_PREAMBLE(e);
+  CHECK_ARG(jsObject);
   CHECK_ARG(result);
 
-  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Object> obj;
-  CHECK_TO_OBJECT(context, obj, jsObject);
+  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
 
-  *result = v8impl::ObjectWrapWrapper::Unwrap(obj);
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_create_persistent(napi_env e, napi_value v, napi_persistent* result) {
-  NAPI_PREAMBLE(e);
-  CHECK_ARG(result);
-
-  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      new v8::Persistent<v8::Value>(
-          isolate, v8impl::V8LocalValueFromJsValue(v));
-
-  *result = v8impl::JsPersistentFromV8PersistentValue(thePersistent);
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_release_persistent(napi_env e, napi_persistent p) {
-  NAPI_PREAMBLE(e);
-
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsPersistentValue(p);
-  thePersistent->Reset();
-  delete thePersistent;
+  assert(obj->InternalFieldCount() > 0);
+  *result = obj->GetAlignedPointerFromInternalField(0);
 
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_get_persistent_value(napi_env e, napi_persistent p, napi_value* result) {
+napi_status napi_create_external(napi_env e,
+                                 void* data,
+                                 napi_finalize finalize_cb,
+                                 napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsPersistentValue(p);
-  v8::Local<v8::Value> napi_value =
-      v8::Local<v8::Value>::New(isolate, *thePersistent);
 
-  *result = v8impl::JsValueFromV8LocalValue(napi_value);
+  v8::Local<v8::Value> externalValue = v8::External::New(isolate, data);
+
+  // The Reference object will delete itself after invoking the finalizer callback.
+  new v8impl::Reference(isolate, externalValue, 0, true, finalize_cb, data);
+
+  *result = v8impl::JsValueFromV8LocalValue(externalValue);
+
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_create_weakref(napi_env e, napi_value v, napi_weakref* result) {
+napi_status napi_get_value_external(napi_env e, napi_value v, void** result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      new v8::Persistent<v8::Value>(
-          isolate, v8impl::V8LocalValueFromJsValue(v));
-  thePersistent->SetWeak(static_cast<int*>(nullptr), v8impl::WeakRefCallback,
-                         v8::WeakCallbackType::kParameter);
-  // need to mark independent?
-  *result = v8impl::JsWeakRefFromV8PersistentValue(thePersistent);
+
+  v8::Local<v8::External> externalValue = v8impl::V8LocalValueFromJsValue(v).As<v8::External>();
+  *result = externalValue->Value();
+
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_get_weakref_value(napi_env e, napi_weakref w, napi_value* result) {
+
+// Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
+// The finalizer callback and callback data parameters optional.
+napi_status napi_create_reference(napi_env e,
+                                  napi_value value,
+                                  int initial_refcount,
+                                  napi_ref* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
+  RETURN_STATUS_IF_FALSE(initial_refcount >= 0, napi_invalid_arg);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsWeakRefValue(w);
-  v8::Local<v8::Value> v =
-      v8::Local<v8::Value>::New(isolate, *thePersistent);
-  if (v.IsEmpty()) {
-    *result = nullptr;
-    return GET_RETURN_STATUS();
+
+  v8impl::Reference* reference = new v8impl::Reference(
+    isolate, v8impl::V8LocalValueFromJsValue(value), initial_refcount, false);
+
+  *result = reinterpret_cast<napi_ref>(reference);
+  return GET_RETURN_STATUS();
+}
+
+// Deletes a reference. The referenced value is released, and may be GC'd unless there
+// are other references to it.
+napi_status napi_delete_reference(napi_env e, napi_ref ref) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
+
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  delete reference;
+
+  return GET_RETURN_STATUS();
+}
+
+// Increments the reference count, optionally returning the resulting count. After this call the
+// reference will be a strong reference because its refcount is >0, and the referenced object is
+// effectively "pinned". Calling this when the refcount is 0 and the object is unavailable
+// results in an error.
+napi_status napi_reference_addref(napi_env e, napi_ref ref, int* result) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
+
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  int count = reference->AddRef();
+
+  if (result != nullptr) {
+    *result = count;
   }
-  *result = v8impl::JsValueFromV8LocalValue(v);
+
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_release_weakref(napi_env e, napi_weakref w) {
+// Decrements the reference count, optionally returning the resulting count. If the result is
+// 0 the reference is now weak and the object may be GC'd at any time if there are no other
+// references. Calling this when the refcount is already 0 results in an error.
+napi_status napi_reference_release(napi_env e, napi_ref ref, int* result) {
   NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
 
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsWeakRefValue(w);
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  int count = reference->Release();
+  if (count < 0) {
+    return napi_set_last_error(napi_generic_failure);
+  }
 
-  thePersistent->Reset();
-  delete thePersistent;
+  if (result != nullptr) {
+    *result = count;
+  }
+
+  return GET_RETURN_STATUS();
+}
+
+// Attempts to get a referenced value. If the reference is weak, the value might no longer be
+// available, in that case the call is still successful but the result is NULL.
+napi_status napi_get_reference_value(napi_env e, napi_ref ref, napi_value* result) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
+  CHECK_ARG(result);
+
+  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
+
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  *result = v8impl::JsValueFromV8LocalValue(reference->Get());
 
   return GET_RETURN_STATUS();
 }
@@ -1816,15 +1869,6 @@ napi_status napi_instanceof(napi_env e, napi_value obj, napi_value cons, bool* r
     }
   }
 
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_make_external(napi_env e, napi_value v, napi_value* result) {
-  NAPI_PREAMBLE(e);
-  CHECK_ARG(result);
-  // v8impl::TryCatch doesn't make sense here since we're not calling into the
-  // engine at all.
-  *result = v;
   return GET_RETURN_STATUS();
 }
 

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -218,12 +218,6 @@ NODE_EXTERN napi_status napi_new_instance(napi_env e,
 NODE_EXTERN napi_status napi_instanceof(napi_env e, napi_value obj,
                                         napi_value cons, bool* result);
 
-// Temporary method needed to support wrapping JavascriptObject in an external
-// object wrapper capable of storing external data. This workaround is only
-// required by ChakraCore and should be removed when we have a method of
-// constructing external objects from the constructor function itself.
-NODE_EXTERN napi_status napi_make_external(napi_env e, napi_value v, napi_value* result);
-
 // Napi version of node::MakeCallback(...)
 NODE_EXTERN napi_status napi_make_callback(napi_env e,
                                            napi_value recv,
@@ -249,21 +243,6 @@ NODE_EXTERN napi_status napi_is_construct_call(napi_env e,
 NODE_EXTERN napi_status napi_set_return_value(napi_env e,
                                   napi_callback_info cbinfo, napi_value v);
 
-// Methods to support ObjectWrap
-// Consider: current implementation for supporting ObjectWrap pattern is
-// difficult to implement for other VMs because of the dependence on node
-// core's node::ObjectWrap type which depends on v8 types and specifically
-// requires the given v8 object to have an internal field count of >= 1.
-// It is proving difficult in the chakracore version of these APIs to
-// implement this natively in JSRT which means that maybe this isn't the
-// best way to attach external data to a javascript object.  Perhaps
-// instead NAPI should do an external data concept like JsSetExternalData
-// and use that for "wrapping a native object".
-NODE_EXTERN napi_status napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
-                                  napi_destruct napi_destructor,
-                                  napi_weakref* handle);
-NODE_EXTERN napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result);
-
 NODE_EXTERN napi_status napi_define_class(napi_env e,
                                           const char* utf8name,
                                           napi_callback constructor,
@@ -272,18 +251,46 @@ NODE_EXTERN napi_status napi_define_class(napi_env e,
                                           const napi_property_descriptor* properties,
                                           napi_value* result);
 
-// Methods to control object lifespan
-NODE_EXTERN napi_status napi_create_persistent(napi_env e, napi_value v,
-                                               napi_persistent* result);
-NODE_EXTERN napi_status napi_release_persistent(napi_env e, napi_persistent p);
-NODE_EXTERN napi_status napi_get_persistent_value(napi_env e, napi_persistent p,
-                                                  napi_value* result);
+// Methods to work with external data objects
+NODE_EXTERN napi_status napi_wrap(napi_env e,
+                                  napi_value jsObject,
+                                  void* nativeObj,
+                                  napi_finalize finalize_cb,
+                                  napi_ref* result);
+NODE_EXTERN napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result);
 
-NODE_EXTERN napi_status napi_create_weakref(napi_env e, napi_value v,
-                                            napi_weakref* result);
-NODE_EXTERN napi_status napi_get_weakref_value(napi_env e, napi_weakref w,
-                                               napi_value* result);
-NODE_EXTERN napi_status napi_release_weakref(napi_env e, napi_weakref w);
+NODE_EXTERN napi_status napi_create_external(napi_env e,
+                                             void* data,
+                                             napi_finalize finalize_cb,
+                                             napi_value* result);
+NODE_EXTERN napi_status napi_get_value_external(napi_env e, napi_value v, void** result);
+
+// Methods to control object lifespan
+
+// Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
+NODE_EXTERN napi_status napi_create_reference(napi_env e,
+                                              napi_value value,
+                                              int initial_refcount,
+                                              napi_ref* result);
+
+// Deletes a reference. The referenced value is released, and may be GC'd unless there
+// are other references to it.
+NODE_EXTERN napi_status napi_delete_reference(napi_env e, napi_ref ref);
+
+// Increments the reference count, optionally returning the resulting count. After this call the
+// reference will be a strong reference because its refcount is >0, and the referenced object is
+// effectively "pinned". Calling this when the refcount is 0 and the object is unavailable
+// results in an error.
+NODE_EXTERN napi_status napi_reference_addref(napi_env e, napi_ref ref, int* result);
+
+// Decrements the reference count, optionally returning the resulting count. If the result is
+// 0 the reference is now weak and the object may be GC'd at any time if there are no other
+// references. Calling this when the refcount is already 0 results in an error.
+NODE_EXTERN napi_status napi_reference_release(napi_env e, napi_ref ref, int* result);
+
+// Attempts to get a referenced value. If the reference is weak, the value might no longer be
+// available, in that case the call is still successful but the result is NULL.
+NODE_EXTERN napi_status napi_get_reference_value(napi_env e, napi_ref ref, napi_value* result);
 
 NODE_EXTERN napi_status napi_open_handle_scope(napi_env e, napi_handle_scope* result);
 NODE_EXTERN napi_status napi_close_handle_scope(napi_env e, napi_handle_scope s);

--- a/src/node_jsvmapi_types.h
+++ b/src/node_jsvmapi_types.h
@@ -8,15 +8,14 @@
 // typedef undefined structs instead of void* for compile time type safety
 typedef struct napi_env__ *napi_env;
 typedef struct napi_value__ *napi_value;
-typedef struct napi_persistent__ *napi_persistent;
-typedef struct napi_weakref__ *napi_weakref;
+typedef struct napi_ref__ *napi_ref;
 typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_propertyname__ *napi_propertyname;
 typedef struct napi_callback_info__ *napi_callback_info;
 
 typedef void (*napi_callback)(napi_env, napi_callback_info);
-typedef void (*napi_destruct)(void* v);
+typedef void (*napi_finalize)(void* v);
 
 enum napi_property_attributes {
   napi_default = 0,
@@ -51,6 +50,7 @@ enum napi_valuetype {
   napi_symbol,
   napi_object,
   napi_function,
+  napi_external,
 };
 
 enum napi_typedarray_type {

--- a/test/addons-abi/6_object_wrap/myobject.h
+++ b/test/addons-abi/6_object_wrap/myobject.h
@@ -17,8 +17,10 @@ class MyObject {
   static void SetValue(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   static void Multiply(napi_env env, napi_callback_info info);
-  static napi_persistent constructor;
+  static napi_ref constructor;
   double value_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_6_OBJECT_WRAP_MYOBJECT_H_

--- a/test/addons-abi/7_factory_wrap/myobject.cc
+++ b/test/addons-abi/7_factory_wrap/myobject.cc
@@ -1,13 +1,16 @@
 #include "myobject.h"
 
-MyObject::MyObject() {}
-MyObject::~MyObject() {}
+MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
+
+MyObject::~MyObject() {
+    napi_delete_reference(env_, wrapper_);
+}
 
 void MyObject::Destructor(void* nativeObject) {
   reinterpret_cast<MyObject*>(nativeObject)->~MyObject();
 }
 
-napi_persistent MyObject::constructor;
+napi_ref MyObject::constructor;
 
 napi_status MyObject::Init(napi_env env) {
   napi_status status;
@@ -19,7 +22,7 @@ napi_status MyObject::Init(napi_env env) {
   status = napi_define_class(env, "MyObject", New, nullptr, 1, properties, &cons);
   if (status != napi_ok) return status;
 
-  status = napi_create_persistent(env, cons, &constructor);
+  status = napi_create_reference(env, cons, 1, &constructor);
   if (status != napi_ok) return status;
 
   return napi_ok;
@@ -50,8 +53,9 @@ void MyObject::New(napi_env env, napi_callback_info info) {
   status = napi_get_cb_this(env, info, &jsthis);
   if (status != napi_ok) return;
 
+  obj->env_ = env;
   status = napi_wrap(env, jsthis, reinterpret_cast<void*>(obj),
-                     MyObject::Destructor, nullptr);
+                     MyObject::Destructor, &obj->wrapper_);
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, jsthis);
@@ -66,7 +70,7 @@ napi_status MyObject::NewInstance(napi_env env, napi_value arg, napi_value* inst
   napi_value argv[argc] = { arg };
 
   napi_value cons;
-  status = napi_get_persistent_value(env, constructor, &cons);
+  status = napi_get_reference_value(env, constructor, &cons);
   if (status != napi_ok) return status;
 
   status = napi_new_instance(env, cons, argc, argv, instance);

--- a/test/addons-abi/7_factory_wrap/myobject.h
+++ b/test/addons-abi/7_factory_wrap/myobject.h
@@ -13,10 +13,12 @@ class MyObject {
   MyObject();
   ~MyObject();
 
-  static napi_persistent constructor;
+  static napi_ref constructor;
   static void New(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   double counter_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_7_FACTORY_WRAP_MYOBJECT_H_

--- a/test/addons-abi/8_passing_wrapped/myobject.h
+++ b/test/addons-abi/8_passing_wrapped/myobject.h
@@ -14,9 +14,11 @@ class MyObject {
   MyObject();
   ~MyObject();
 
-  static napi_persistent constructor;
+  static napi_ref constructor;
   static void New(napi_env env, napi_callback_info info);
   double val_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_8_PASSING_WRAPPED_MYOBJECT_H_

--- a/test/addons-abi/test_constructor/test_constructor.cc
+++ b/test/addons-abi/test_constructor/test_constructor.cc
@@ -1,7 +1,7 @@
 #include <node_jsvmapi.h>
 
 static double value_ = 1;
-napi_persistent constructor_;
+napi_ref constructor_;
 
 void GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
@@ -102,7 +102,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   status = napi_set_property(env, module, name, cons);
   if (status != napi_ok) return;
 
-  status = napi_create_persistent(env, cons, &constructor_);
+  status = napi_create_reference(env, cons, 1, &constructor_);
   if (status != napi_ok) return;
 }
 


### PR DESCRIPTION
I've filled out and refined the concept I showed last week. The object model is mostly complete now; I think the only missing piece is corresponding wrappers for the libuv async APIs.

I don't think you'll find anything too surprising here since it's mostly a faithful object-oriented interpretation of the NAPI APIs we already had. The interesting/clever parts to look at are:
 * `Napi::Value` class hierarchy and `As*` / `To*` conversions. (Actually this is very similar to V8's object model.)
 * JavaScript & C++ exception unification: see comments on the `Napi::Error` class.
 * `ObjectWrap` callback registration and handling that enables natural use of `this`, return values, and exceptions.

Overall, I think the result is a better/cleaner development experience than what you get from using NAN or Node/V8 APIs directly. Hopefully that will be another reason native module developers might want to use this API.

I kept the type declarations (`napi.h`) separate from the implementations (`napi-inl.h`) because it's much easier get a grasp of the object model that way, at least in the absence of any other documentation. I think the new headers should completely supersede `node_api_helpers.h`, though I have not modified or deleted that file yet because some test/example code still uses it.

I also made a couple small changes to the C API surface: `napi_define_class` and `napi_define_properties`, to better support / be more consistent with the C++ wrappers.

I validated all this using the canvas module, which is now fully ported using these C++ APIs, and covers a very significant portion of them. The Canvas tests all pass, with the exception of those that are dependent on typed arrays. For examples of converted code see [`Canvas.h`](https://github.com/jasongin/node-canvas/blob/napi2/src/Canvas.h) and [`Canvas.cc`](https://github.com/jasongin/node-canvas/blob/napi2/src/Canvas.cc) or the [complete diff of the Canvas port to NAPI](https://github.com/Automattic/node-canvas/compare/master...jasongin:napi2?expand=1).

While I've included the new headers in the regular node `src` directory for now, I actually think they might belong in their own repo, where they'd get published via an NPM, similar to NAN.