### PR TITLE
RangeError APIs (V8)

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -1093,6 +1093,17 @@ napi_status napi_create_type_error(napi_env e, napi_value msg, napi_value* resul
   return GET_RETURN_STATUS();
 }
 
+napi_status napi_create_range_error(napi_env e, napi_value msg, napi_value* result) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(result);
+
+  *result = v8impl::JsValueFromV8LocalValue(
+    v8::Exception::RangeError(
+      v8impl::V8LocalValueFromJsValue(msg).As<v8::String>()));
+
+  return GET_RETURN_STATUS();
+}
+
 napi_status napi_get_type_of_value(napi_env e, napi_value vv, napi_valuetype* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -1319,6 +1330,19 @@ napi_status napi_throw_type_error(napi_env e, const char* msg) {
   CHECK_NEW_FROM_UTF8(isolate, str, msg);
 
   isolate->ThrowException(v8::Exception::TypeError(str));
+  // any VM calls after this point and before returning
+  // to the javascript invoker will fail
+  return napi_ok;
+}
+
+napi_status napi_throw_range_error(napi_env e, const char* msg) {
+  NAPI_PREAMBLE(e);
+
+  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
+  v8::Local<v8::String> str;
+  CHECK_NEW_FROM_UTF8(isolate, str, msg);
+
+  isolate->ThrowException(v8::Exception::RangeError(str));
   // any VM calls after this point and before returning
   // to the javascript invoker will fail
   return napi_ok;

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -130,6 +130,7 @@ NODE_EXTERN napi_status napi_create_function(napi_env e, napi_callback cb,
                                                  void* data, napi_value* result);
 NODE_EXTERN napi_status napi_create_error(napi_env e, napi_value msg, napi_value* result);
 NODE_EXTERN napi_status napi_create_type_error(napi_env e, napi_value msg, napi_value* result);
+NODE_EXTERN napi_status napi_create_range_error(napi_env e, napi_value msg, napi_value* result);
 
 // Methods to get the the native napi_value from Primitive type
 NODE_EXTERN napi_status napi_get_type_of_value(napi_env e, napi_value vv, napi_valuetype* result);
@@ -297,6 +298,7 @@ NODE_EXTERN napi_status napi_escape_handle(napi_env e,
 NODE_EXTERN napi_status napi_throw(napi_env e, napi_value error);
 NODE_EXTERN napi_status napi_throw_error(napi_env e, const char* msg);
 NODE_EXTERN napi_status napi_throw_type_error(napi_env e, const char* msg);
+NODE_EXTERN napi_status napi_throw_range_error(napi_env e, const char* msg);
 
 // Methods to support catching exceptions
 NODE_EXTERN napi_status napi_is_exception_pending(napi_env e, bool* result);


### PR DESCRIPTION
I pulled this out of my [C++ wrapper classes](https://github.com/nodejs/abi-stable-node/pull/88) PR, since that was doing too many things in the same PR.

This is needed for the node-canvas port to NAPI, because some of its unit tests expect RangeErrors.