### PR TITLE
Fix build errors

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -217,7 +217,7 @@ namespace v8impl {
       }
 
       virtual void* Data() override {
-        return _cbdata->GetInternalField(kDataIndex).As<v8::External>()->Value();
+        return v8::Local<v8::External>::Cast(_cbdata->GetInternalField(kDataIndex))->Value();
       }
 
     protected:
@@ -225,7 +225,7 @@ namespace v8impl {
         napi_callback_info cbinfo_wrapper = reinterpret_cast<napi_callback_info>(
           static_cast<CallbackWrapper*>(this));
         napi_callback cb = reinterpret_cast<napi_callback>(
-          _cbdata->GetInternalField(I).As<v8::External>()->Value());
+          v8::Local<v8::External>::Cast(_cbdata->GetInternalField(I))->Value());
         v8::Isolate* isolate = _cbinfo.GetIsolate();
         cb(v8impl::JsEnvFromV8Isolate(isolate), cbinfo_wrapper);
 

--- a/src/node_jsvmapi_types.h
+++ b/src/node_jsvmapi_types.h
@@ -1,6 +1,7 @@
 ﻿#ifndef SRC_NODE_JSVMAPI_TYPES_H_
 #define SRC_NODE_JSVMAPI_TYPES_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 // JSVM API types are all opaque pointers for ABI stability


### PR DESCRIPTION
This fixes a couple build errors that I saw on a Mac, after my recent changes that I had built only on Windows. Sorry about that.

(For anyone unfamiliar with the template disambiguator syntax used here, see the bottom of [this page](http://en.cppreference.com/w/cpp/language/dependent_name).)