### PR TITLE
Reference and external improvements (V8)

### DIFF
--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -138,7 +138,7 @@ namespace Napi {
       HandleScope scope(env);
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &handle);
+      napi_create_reference(env, obj, 1, &handle);
     }
 
     explicit Callback(napi_value fn) {
@@ -147,7 +147,7 @@ namespace Napi {
       HandleScope scope(env);
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &handle);
+      napi_create_reference(env, obj, 1, &handle);
       SetFunction(fn);
     }
 
@@ -158,7 +158,7 @@ namespace Napi {
 
       napi_env env;
       napi_get_current_env(&env);
-      napi_release_persistent(env, handle);
+      napi_delete_reference(env, handle);
     }
 
     bool operator==(const Callback &other) const {
@@ -167,9 +167,9 @@ namespace Napi {
       napi_get_current_env(&env);
 
       napi_value ha;
-      napi_get_persistent_value(env, handle, &ha);
+      napi_get_reference_value(env, handle, &ha);
       napi_value hb;
-      napi_get_persistent_value(env, other.handle, &hb);
+      napi_get_reference_value(env, other.handle, &hb);
 
       napi_value a;
       napi_get_element(env, ha, kCallbackIndex, &a);
@@ -206,7 +206,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_set_element(env, h, kCallbackIndex, fn);
     }
 
@@ -215,7 +215,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
       return scope.Escape(fn);
@@ -226,7 +226,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
       napi_valuetype valuetype;
@@ -252,7 +252,7 @@ namespace Napi {
 
    private:
     NAPI_DISALLOW_ASSIGN_COPY_MOVE(Callback)
-    napi_persistent handle;
+    napi_ref handle;
     static const uint32_t kCallbackIndex = 0;
 
     napi_value Call_(napi_value target,
@@ -263,7 +263,7 @@ namespace Napi {
       napi_get_current_env(&env);
 
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
 
@@ -293,7 +293,7 @@ namespace Napi {
       HandleScope scope;
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &persistentHandle);
+      napi_create_reference(env, obj, 1, &persistentHandle);
     }
 
     virtual ~AsyncWorker() {
@@ -302,7 +302,7 @@ namespace Napi {
       if (persistentHandle != NULL) {
         napi_env env;
         napi_get_current_env(&env);
-        napi_release_persistent(env, persistentHandle);
+        napi_delete_reference(env, persistentHandle);
         persistentHandle = NULL;
       }
       delete callback;
@@ -330,7 +330,7 @@ namespace Napi {
       napi_propertyname pnKey;
       napi_property_name(env, key, &pnKey);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_property(env, h, pnKey, value);
     }
 
@@ -340,7 +340,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_property(env, h, key, value);
     }
 
@@ -350,7 +350,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_element(env, h, index, value);
     }
 
@@ -361,7 +361,7 @@ namespace Napi {
       napi_propertyname pnKey;
       napi_property_name(env, key, &pnKey);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_property(env, h, pnKey, &v);
       return scope.Escape(v);
@@ -373,7 +373,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_property(env, h, key, &v);
       return scope.Escape(v);
@@ -384,7 +384,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_element(env, h, index, &v);
       return scope.Escape(v);
@@ -414,7 +414,7 @@ namespace Napi {
     }
 
    protected:
-    napi_persistent persistentHandle;
+    napi_ref persistentHandle;
     Callback *callback;
 
     virtual void HandleOKCallback() {

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -131,28 +131,78 @@ namespace v8impl {
     return u.f;
   }
 
-  static napi_persistent JsPersistentFromV8PersistentValue(
-                                             v8::Persistent<v8::Value> *per) {
-    return (napi_persistent) per;
-  }
+  // Wrapper around v8::Persistent that implements reference counting.
+  class Reference {
+  public:
+    Reference(v8::Isolate* isolate,
+              v8::Local<v8::Value> value,
+              int initialRefcount,
+              bool deleteSelf,
+              napi_finalize finalizeCallback = nullptr,
+              void* finalizeData = nullptr)
+      : _isolate(isolate),
+        _persistent(isolate, value),
+        _refcount(initialRefcount),
+        _deleteSelf(deleteSelf),
+        _finalizeCallback(finalizeCallback),
+        _finalizeData(finalizeData) {
+      if (initialRefcount == 0) {
+        _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        _persistent.MarkIndependent();
+      }
+    }
 
-  static v8::Persistent<v8::Value>* V8PersistentValueFromJsPersistentValue(
-                                                        napi_persistent per) {
-    return (v8::Persistent<v8::Value>*) per;
-  }
+    ~Reference() {
+      _persistent.Reset();
+    }
 
-  static napi_weakref JsWeakRefFromV8PersistentValue(
-                                             v8::Persistent<v8::Value> *per) {
-    return (napi_weakref) per;
-  }
+    int AddRef() {
+      if (++_refcount == 1) {
+        _persistent.ClearWeak();
+      }
 
-  static v8::Persistent<v8::Value>* V8PersistentValueFromJsWeakRefValue(
-                                                           napi_weakref per) {
-    return (v8::Persistent<v8::Value>*) per;
-  }
+      return _refcount;
+    }
 
-  static void WeakRefCallback(const v8::WeakCallbackInfo<int>& data) {
-  }
+    int Release() {
+      if (--_refcount == 0) {
+        _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        _persistent.MarkIndependent();
+      }
+
+      return _refcount;
+    }
+
+    v8::Local<v8::Value> Get() {
+      if (_persistent.IsEmpty()) {
+        return v8::Local<v8::Value>();
+      }
+      else {
+        return _persistent.Get(_isolate);
+      }
+    }
+
+  private:
+    static void FinalizeCallback(const v8::WeakCallbackInfo<Reference>& data) {
+      Reference* reference = data.GetParameter();
+      reference->_persistent.Reset();
+
+      if (reference->_finalizeCallback != nullptr) {
+        reference->_finalizeCallback(reference->_finalizeData);
+      }
+
+      if (reference->_deleteSelf) {
+        delete reference;
+      }
+    }
+
+    v8::Isolate* _isolate;
+    v8::Persistent<v8::Value> _persistent;
+    int _refcount;
+    bool _deleteSelf;
+    napi_finalize _finalizeCallback;
+    void* _finalizeData;
+  };
 
   class TryCatch: public v8::TryCatch {
     public:
@@ -361,36 +411,6 @@ namespace v8impl {
 
     private:
       const v8::Local<v8::Value>& _value;
-  };
-
-  class ObjectWrapWrapper: public node::ObjectWrap {
-    public:
-      ObjectWrapWrapper(v8::Local<v8::Object> jsObject, void* nativeObj,
-                        napi_destruct destructor) {
-        _destructor = destructor;
-        _nativeObj = nativeObj;
-        Wrap(jsObject);
-      }
-
-      void* getValue() {
-        return _nativeObj;
-      }
-
-      static void* Unwrap(v8::Local<v8::Object> jsObject) {
-        ObjectWrapWrapper* wrapper =
-            ObjectWrap::Unwrap<ObjectWrapWrapper>(jsObject);
-        return wrapper->getValue();
-      }
-
-      virtual ~ObjectWrapWrapper() {
-        if (_destructor != nullptr) {
-          _destructor(_nativeObj);
-        }
-      }
-
-    private:
-      napi_destruct _destructor;
-      void* _nativeObj;
   };
 
   // Creates an object to be made available to the static function callback
@@ -1153,6 +1173,8 @@ napi_status napi_get_type_of_value(napi_env e, napi_value vv, napi_valuetype* re
     *result = napi_symbol;
   } else if (v->IsNull()) {
     *result = napi_null;
+  } else if (v->IsExternal()) {
+    *result = napi_external;
   } else {
     *result = napi_object;   // Is this correct?
   }
@@ -1569,122 +1591,153 @@ napi_status napi_coerce_to_string(napi_env e, napi_value v, napi_value* result) 
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
-                      napi_destruct destructor, napi_weakref* handle) {
+napi_status napi_wrap(napi_env e,
+                      napi_value jsObject,
+                      void* nativeObj,
+                      napi_finalize finalize_cb,
+                      napi_ref* result) {
   NAPI_PREAMBLE(e);
+  CHECK_ARG(jsObject);
+  CHECK_ARG(result);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Object> obj;
-  CHECK_TO_OBJECT(context, obj, jsObject);
 
-  v8impl::ObjectWrapWrapper* wrap =
-      new v8impl::ObjectWrapWrapper(obj, nativeObj, destructor);
+  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
+  assert(obj->InternalFieldCount() > 0);
+  obj->SetAlignedPointerInInternalField(0, nativeObj);
 
-  if (handle)
-  {
-    return napi_create_weakref(
-      e,
-      v8impl::JsValueFromV8LocalValue(wrap->handle()),
-      handle);
-  }
+  v8impl::Reference* reference = new v8impl::Reference(
+    isolate, obj, 0, false, finalize_cb, nativeObj);
+  *result = reinterpret_cast<napi_ref>(reference);
 
-  // TODO: Is the handle parameter really optional?
-  //       Why would anyone want to construct an object wrap and immediately lose it?
   return GET_RETURN_STATUS();
 }
 
 napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result) {
   NAPI_PREAMBLE(e);
+  CHECK_ARG(jsObject);
   CHECK_ARG(result);
 
-  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Object> obj;
-  CHECK_TO_OBJECT(context, obj, jsObject);
+  v8::Local<v8::Object> obj = v8impl::V8LocalValueFromJsValue(jsObject).As<v8::Object>();
 
-  *result = v8impl::ObjectWrapWrapper::Unwrap(obj);
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_create_persistent(napi_env e, napi_value v, napi_persistent* result) {
-  NAPI_PREAMBLE(e);
-  CHECK_ARG(result);
-
-  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      new v8::Persistent<v8::Value>(
-          isolate, v8impl::V8LocalValueFromJsValue(v));
-
-  *result = v8impl::JsPersistentFromV8PersistentValue(thePersistent);
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_release_persistent(napi_env e, napi_persistent p) {
-  NAPI_PREAMBLE(e);
-
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsPersistentValue(p);
-  thePersistent->Reset();
-  delete thePersistent;
+  assert(obj->InternalFieldCount() > 0);
+  *result = obj->GetAlignedPointerFromInternalField(0);
 
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_get_persistent_value(napi_env e, napi_persistent p, napi_value* result) {
+napi_status napi_create_external(napi_env e,
+                                 void* data,
+                                 napi_finalize finalize_cb,
+                                 napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsPersistentValue(p);
-  v8::Local<v8::Value> napi_value =
-      v8::Local<v8::Value>::New(isolate, *thePersistent);
 
-  *result = v8impl::JsValueFromV8LocalValue(napi_value);
+  v8::Local<v8::Value> externalValue = v8::External::New(isolate, data);
+
+  // The Reference object will delete itself after invoking the finalizer callback.
+  new v8impl::Reference(isolate, externalValue, 0, true, finalize_cb, data);
+
+  *result = v8impl::JsValueFromV8LocalValue(externalValue);
+
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_create_weakref(napi_env e, napi_value v, napi_weakref* result) {
+napi_status napi_get_value_external(napi_env e, napi_value v, void** result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      new v8::Persistent<v8::Value>(
-          isolate, v8impl::V8LocalValueFromJsValue(v));
-  thePersistent->SetWeak(static_cast<int*>(nullptr), v8impl::WeakRefCallback,
-                         v8::WeakCallbackType::kParameter);
-  // need to mark independent?
-  *result = v8impl::JsWeakRefFromV8PersistentValue(thePersistent);
+
+  v8::Local<v8::External> externalValue = v8impl::V8LocalValueFromJsValue(v).As<v8::External>();
+  *result = externalValue->Value();
+
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_get_weakref_value(napi_env e, napi_weakref w, napi_value* result) {
+
+// Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
+// The finalizer callback and callback data parameters optional.
+napi_status napi_create_reference(napi_env e,
+                                  napi_value value,
+                                  int initial_refcount,
+                                  napi_ref* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
+  RETURN_STATUS_IF_FALSE(initial_refcount >= 0, napi_invalid_arg);
 
   v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsWeakRefValue(w);
-  v8::Local<v8::Value> v =
-      v8::Local<v8::Value>::New(isolate, *thePersistent);
-  if (v.IsEmpty()) {
-    *result = nullptr;
-    return GET_RETURN_STATUS();
+
+  v8impl::Reference* reference = new v8impl::Reference(
+    isolate, v8impl::V8LocalValueFromJsValue(value), initial_refcount, false);
+
+  *result = reinterpret_cast<napi_ref>(reference);
+  return GET_RETURN_STATUS();
+}
+
+// Deletes a reference. The referenced value is released, and may be GC'd unless there
+// are other references to it.
+napi_status napi_delete_reference(napi_env e, napi_ref ref) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
+
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  delete reference;
+
+  return GET_RETURN_STATUS();
+}
+
+// Increments the reference count, optionally returning the resulting count. After this call the
+// reference will be a strong reference because its refcount is >0, and the referenced object is
+// effectively "pinned". Calling this when the refcount is 0 and the object is unavailable
+// results in an error.
+napi_status napi_reference_addref(napi_env e, napi_ref ref, int* result) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
+
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  int count = reference->AddRef();
+
+  if (result != nullptr) {
+    *result = count;
   }
-  *result = v8impl::JsValueFromV8LocalValue(v);
+
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_release_weakref(napi_env e, napi_weakref w) {
+// Decrements the reference count, optionally returning the resulting count. If the result is
+// 0 the reference is now weak and the object may be GC'd at any time if there are no other
+// references. Calling this when the refcount is already 0 results in an error.
+napi_status napi_reference_release(napi_env e, napi_ref ref, int* result) {
   NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
 
-  v8::Persistent<v8::Value> *thePersistent =
-      v8impl::V8PersistentValueFromJsWeakRefValue(w);
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  int count = reference->Release();
+  if (count < 0) {
+    return napi_set_last_error(napi_generic_failure);
+  }
 
-  thePersistent->Reset();
-  delete thePersistent;
+  if (result != nullptr) {
+    *result = count;
+  }
+
+  return GET_RETURN_STATUS();
+}
+
+// Attempts to get a referenced value. If the reference is weak, the value might no longer be
+// available, in that case the call is still successful but the result is NULL.
+napi_status napi_get_reference_value(napi_env e, napi_ref ref, napi_value* result) {
+  NAPI_PREAMBLE(e);
+  CHECK_ARG(ref);
+  CHECK_ARG(result);
+
+  v8::Isolate *isolate = v8impl::V8IsolateFromJsEnv(e);
+
+  v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
+  *result = v8impl::JsValueFromV8LocalValue(reference->Get());
 
   return GET_RETURN_STATUS();
 }
@@ -1816,15 +1869,6 @@ napi_status napi_instanceof(napi_env e, napi_value obj, napi_value cons, bool* r
     }
   }
 
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_make_external(napi_env e, napi_value v, napi_value* result) {
-  NAPI_PREAMBLE(e);
-  CHECK_ARG(result);
-  // v8impl::TryCatch doesn't make sense here since we're not calling into the
-  // engine at all.
-  *result = v;
   return GET_RETURN_STATUS();
 }
 

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -218,12 +218,6 @@ NODE_EXTERN napi_status napi_new_instance(napi_env e,
 NODE_EXTERN napi_status napi_instanceof(napi_env e, napi_value obj,
                                         napi_value cons, bool* result);
 
-// Temporary method needed to support wrapping JavascriptObject in an external
-// object wrapper capable of storing external data. This workaround is only
-// required by ChakraCore and should be removed when we have a method of
-// constructing external objects from the constructor function itself.
-NODE_EXTERN napi_status napi_make_external(napi_env e, napi_value v, napi_value* result);
-
 // Napi version of node::MakeCallback(...)
 NODE_EXTERN napi_status napi_make_callback(napi_env e,
                                            napi_value recv,
@@ -249,21 +243,6 @@ NODE_EXTERN napi_status napi_is_construct_call(napi_env e,
 NODE_EXTERN napi_status napi_set_return_value(napi_env e,
                                   napi_callback_info cbinfo, napi_value v);
 
-// Methods to support ObjectWrap
-// Consider: current implementation for supporting ObjectWrap pattern is
-// difficult to implement for other VMs because of the dependence on node
-// core's node::ObjectWrap type which depends on v8 types and specifically
-// requires the given v8 object to have an internal field count of >= 1.
-// It is proving difficult in the chakracore version of these APIs to
-// implement this natively in JSRT which means that maybe this isn't the
-// best way to attach external data to a javascript object.  Perhaps
-// instead NAPI should do an external data concept like JsSetExternalData
-// and use that for "wrapping a native object".
-NODE_EXTERN napi_status napi_wrap(napi_env e, napi_value jsObject, void* nativeObj,
-                                  napi_destruct napi_destructor,
-                                  napi_weakref* handle);
-NODE_EXTERN napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result);
-
 NODE_EXTERN napi_status napi_define_class(napi_env e,
                                           const char* utf8name,
                                           napi_callback constructor,
@@ -272,18 +251,46 @@ NODE_EXTERN napi_status napi_define_class(napi_env e,
                                           const napi_property_descriptor* properties,
                                           napi_value* result);
 
-// Methods to control object lifespan
-NODE_EXTERN napi_status napi_create_persistent(napi_env e, napi_value v,
-                                               napi_persistent* result);
-NODE_EXTERN napi_status napi_release_persistent(napi_env e, napi_persistent p);
-NODE_EXTERN napi_status napi_get_persistent_value(napi_env e, napi_persistent p,
-                                                  napi_value* result);
+// Methods to work with external data objects
+NODE_EXTERN napi_status napi_wrap(napi_env e,
+                                  napi_value jsObject,
+                                  void* nativeObj,
+                                  napi_finalize finalize_cb,
+                                  napi_ref* result);
+NODE_EXTERN napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result);
 
-NODE_EXTERN napi_status napi_create_weakref(napi_env e, napi_value v,
-                                            napi_weakref* result);
-NODE_EXTERN napi_status napi_get_weakref_value(napi_env e, napi_weakref w,
-                                               napi_value* result);
-NODE_EXTERN napi_status napi_release_weakref(napi_env e, napi_weakref w);
+NODE_EXTERN napi_status napi_create_external(napi_env e,
+                                             void* data,
+                                             napi_finalize finalize_cb,
+                                             napi_value* result);
+NODE_EXTERN napi_status napi_get_value_external(napi_env e, napi_value v, void** result);
+
+// Methods to control object lifespan
+
+// Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
+NODE_EXTERN napi_status napi_create_reference(napi_env e,
+                                              napi_value value,
+                                              int initial_refcount,
+                                              napi_ref* result);
+
+// Deletes a reference. The referenced value is released, and may be GC'd unless there
+// are other references to it.
+NODE_EXTERN napi_status napi_delete_reference(napi_env e, napi_ref ref);
+
+// Increments the reference count, optionally returning the resulting count. After this call the
+// reference will be a strong reference because its refcount is >0, and the referenced object is
+// effectively "pinned". Calling this when the refcount is 0 and the object is unavailable
+// results in an error.
+NODE_EXTERN napi_status napi_reference_addref(napi_env e, napi_ref ref, int* result);
+
+// Decrements the reference count, optionally returning the resulting count. If the result is
+// 0 the reference is now weak and the object may be GC'd at any time if there are no other
+// references. Calling this when the refcount is already 0 results in an error.
+NODE_EXTERN napi_status napi_reference_release(napi_env e, napi_ref ref, int* result);
+
+// Attempts to get a referenced value. If the reference is weak, the value might no longer be
+// available, in that case the call is still successful but the result is NULL.
+NODE_EXTERN napi_status napi_get_reference_value(napi_env e, napi_ref ref, napi_value* result);
 
 NODE_EXTERN napi_status napi_open_handle_scope(napi_env e, napi_handle_scope* result);
 NODE_EXTERN napi_status napi_close_handle_scope(napi_env e, napi_handle_scope s);

--- a/src/node_jsvmapi_types.h
+++ b/src/node_jsvmapi_types.h
@@ -8,15 +8,14 @@
 // typedef undefined structs instead of void* for compile time type safety
 typedef struct napi_env__ *napi_env;
 typedef struct napi_value__ *napi_value;
-typedef struct napi_persistent__ *napi_persistent;
-typedef struct napi_weakref__ *napi_weakref;
+typedef struct napi_ref__ *napi_ref;
 typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_propertyname__ *napi_propertyname;
 typedef struct napi_callback_info__ *napi_callback_info;
 
 typedef void (*napi_callback)(napi_env, napi_callback_info);
-typedef void (*napi_destruct)(void* v);
+typedef void (*napi_finalize)(void* v);
 
 enum napi_property_attributes {
   napi_default = 0,
@@ -51,6 +50,7 @@ enum napi_valuetype {
   napi_symbol,
   napi_object,
   napi_function,
+  napi_external,
 };
 
 enum napi_typedarray_type {

--- a/test/addons-abi/6_object_wrap/myobject.h
+++ b/test/addons-abi/6_object_wrap/myobject.h
@@ -17,8 +17,10 @@ class MyObject {
   static void SetValue(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   static void Multiply(napi_env env, napi_callback_info info);
-  static napi_persistent constructor;
+  static napi_ref constructor;
   double value_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_6_OBJECT_WRAP_MYOBJECT_H_

--- a/test/addons-abi/7_factory_wrap/myobject.cc
+++ b/test/addons-abi/7_factory_wrap/myobject.cc
@@ -1,13 +1,16 @@
 #include "myobject.h"
 
-MyObject::MyObject() {}
-MyObject::~MyObject() {}
+MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
+
+MyObject::~MyObject() {
+    napi_delete_reference(env_, wrapper_);
+}
 
 void MyObject::Destructor(void* nativeObject) {
   reinterpret_cast<MyObject*>(nativeObject)->~MyObject();
 }
 
-napi_persistent MyObject::constructor;
+napi_ref MyObject::constructor;
 
 napi_status MyObject::Init(napi_env env) {
   napi_status status;
@@ -19,7 +22,7 @@ napi_status MyObject::Init(napi_env env) {
   status = napi_define_class(env, "MyObject", New, nullptr, 1, properties, &cons);
   if (status != napi_ok) return status;
 
-  status = napi_create_persistent(env, cons, &constructor);
+  status = napi_create_reference(env, cons, 1, &constructor);
   if (status != napi_ok) return status;
 
   return napi_ok;
@@ -50,8 +53,9 @@ void MyObject::New(napi_env env, napi_callback_info info) {
   status = napi_get_cb_this(env, info, &jsthis);
   if (status != napi_ok) return;
 
+  obj->env_ = env;
   status = napi_wrap(env, jsthis, reinterpret_cast<void*>(obj),
-                     MyObject::Destructor, nullptr);
+                     MyObject::Destructor, &obj->wrapper_);
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, jsthis);
@@ -66,7 +70,7 @@ napi_status MyObject::NewInstance(napi_env env, napi_value arg, napi_value* inst
   napi_value argv[argc] = { arg };
 
   napi_value cons;
-  status = napi_get_persistent_value(env, constructor, &cons);
+  status = napi_get_reference_value(env, constructor, &cons);
   if (status != napi_ok) return status;
 
   status = napi_new_instance(env, cons, argc, argv, instance);

--- a/test/addons-abi/7_factory_wrap/myobject.h
+++ b/test/addons-abi/7_factory_wrap/myobject.h
@@ -13,10 +13,12 @@ class MyObject {
   MyObject();
   ~MyObject();
 
-  static napi_persistent constructor;
+  static napi_ref constructor;
   static void New(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   double counter_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_7_FACTORY_WRAP_MYOBJECT_H_

--- a/test/addons-abi/8_passing_wrapped/myobject.h
+++ b/test/addons-abi/8_passing_wrapped/myobject.h
@@ -14,9 +14,11 @@ class MyObject {
   MyObject();
   ~MyObject();
 
-  static napi_persistent constructor;
+  static napi_ref constructor;
   static void New(napi_env env, napi_callback_info info);
   double val_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_8_PASSING_WRAPPED_MYOBJECT_H_

--- a/test/addons-abi/test_constructor/test_constructor.cc
+++ b/test/addons-abi/test_constructor/test_constructor.cc
@@ -1,7 +1,7 @@
 #include <node_jsvmapi.h>
 
 static double value_ = 1;
-napi_persistent constructor_;
+napi_ref constructor_;
 
 void GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
@@ -102,7 +102,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   status = napi_set_property(env, module, name, cons);
   if (status != napi_ok) return;
 
-  status = napi_create_persistent(env, cons, &constructor_);
+  status = napi_create_reference(env, cons, 1, &constructor_);
   if (status != napi_ok) return;
 }
 


### PR DESCRIPTION
 - Add new "external" value type and APIs
 - Replace persistent and weak-ref types and APIs with unified counted-reference `napi_ref` type and APIs
 - Update wrap/unwrap APIs to use reference type

Reviewers: I recommend looking at `node_jsvmapi.h` first to get an overview of the new/changed APIs.

This is mostly the design I proposed at https://github.com/nodejs/abi-stable-node/issues/93, with minor corrections for issues discovered during implementation.

I will update the C++ wrapper's `ObjectWrap` class to uses the updated `napi_wrap` API, now with the needed ref/unref capability via the new `napi_ref` type.