### PR TITLE
RangeError APIs (ChakraCore)

### DIFF
--- a/src/node_jsrtapi.cc
+++ b/src/node_jsrtapi.cc
@@ -604,6 +604,13 @@ napi_status napi_create_type_error(napi_env, napi_value msg, napi_value* result)
   return napi_ok;
 }
 
+napi_status napi_create_range_error(napi_env, napi_value msg, napi_value* result) {
+  CHECK_ARG(result);
+  JsValueRef message = reinterpret_cast<JsValueRef>(msg);
+  CHECK_JSRT(JsCreateRangeError(message, reinterpret_cast<JsValueRef*>(result)));
+  return napi_ok;
+}
+
 napi_status napi_get_type_of_value(napi_env e, napi_value vv, napi_valuetype* result) {
   CHECK_ARG(result);
   JsValueRef value = reinterpret_cast<JsValueRef>(vv);
@@ -757,6 +764,16 @@ napi_status napi_throw_type_error(napi_env e, const char* msg) {
   size_t length = strlen(msg);
   CHECK_JSRT(JsCreateStringUtf8((uint8_t*)msg, length, &strRef));
   CHECK_JSRT(JsCreateTypeError(strRef, &exception));
+  CHECK_JSRT(JsSetException(exception));
+  return napi_ok;
+}
+
+napi_status napi_throw_range_error(napi_env e, const char* msg) {
+  JsValueRef strRef;
+  JsValueRef exception;
+  size_t length = strlen(msg);
+  CHECK_JSRT(JsCreateStringUtf8((uint8_t*)msg, length, &strRef));
+  CHECK_JSRT(JsCreateRangeError(strRef, &exception));
   CHECK_JSRT(JsSetException(exception));
   return napi_ok;
 }

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -130,6 +130,7 @@ NODE_EXTERN napi_status napi_create_function(napi_env e, napi_callback cb,
                                                  void* data, napi_value* result);
 NODE_EXTERN napi_status napi_create_error(napi_env e, napi_value msg, napi_value* result);
 NODE_EXTERN napi_status napi_create_type_error(napi_env e, napi_value msg, napi_value* result);
+NODE_EXTERN napi_status napi_create_range_error(napi_env e, napi_value msg, napi_value* result);
 
 // Methods to get the the native napi_value from Primitive type
 NODE_EXTERN napi_status napi_get_type_of_value(napi_env e, napi_value vv, napi_valuetype* result);
@@ -297,6 +298,7 @@ NODE_EXTERN napi_status napi_escape_handle(napi_env e,
 NODE_EXTERN napi_status napi_throw(napi_env e, napi_value error);
 NODE_EXTERN napi_status napi_throw_error(napi_env e, const char* msg);
 NODE_EXTERN napi_status napi_throw_type_error(napi_env e, const char* msg);
+NODE_EXTERN napi_status napi_throw_range_error(napi_env e, const char* msg);
 
 // Methods to support catching exceptions
 NODE_EXTERN napi_status napi_is_exception_pending(napi_env e, bool* result);


### PR DESCRIPTION
This is the ChakraCore implementation of the NAPI RangeError APIs [already done for V8](https://github.com/nodejs/abi-stable-node/pull/95).