### PR TITLE
Property & class definition improvements (ChakraCore)

### DIFF
--- a/src/node_jsrtapi.cc
+++ b/src/node_jsrtapi.cc
@@ -23,6 +23,7 @@
 #include <node_object_wrap.h>
 #include <env.h>
 #include <vector>
+#include <algorithm>
 #include "ChakraCore.h"
 
 #include "src/jsrtutils.h"
@@ -332,8 +333,7 @@ napi_status napi_define_class(napi_env e,
   }
 
   std::vector<napi_property_descriptor> descriptors;
-  descriptors.reserve(instancePropertyCount > staticPropertyCount ?
-    instancePropertyCount : staticPropertyCount);
+  descriptors.reserve(std::max(instancePropertyCount, staticPropertyCount));
 
   if (instancePropertyCount > 0) {
     for (int i = 0; i < property_count; i++) {
@@ -407,66 +407,70 @@ napi_status napi_define_properties(napi_env e,
                                    napi_value o,
                                    int property_count,
                                    const napi_property_descriptor* properties) {
-  napi_propertyname configurableProperty;
-  CHECK_NAPI(napi_property_name(e, "configurable", &configurableProperty));
+  JsPropertyIdRef configurableProperty;
+  CHECK_JSRT(JsCreatePropertyIdUtf8("configurable", 12, &configurableProperty));
 
-  napi_propertyname enumerableProperty;
-  CHECK_NAPI(napi_property_name(e, "enumerable", &enumerableProperty));
+  JsPropertyIdRef enumerableProperty;
+  CHECK_JSRT(JsCreatePropertyIdUtf8("enumerable", 10, &enumerableProperty));
 
   for (int i = 0; i < property_count; i++) {
     const napi_property_descriptor* p = properties + i;
 
-    napi_value descriptor;
-    CHECK_NAPI(napi_create_object(e, &descriptor));
+    JsValueRef descriptor;
+    CHECK_JSRT(JsCreateObject(&descriptor));
 
-    napi_value configurable;
-    CHECK_NAPI(napi_create_boolean(e, !(p->attributes & napi_dont_delete), &configurable));
-    CHECK_NAPI(napi_set_property(e, descriptor, configurableProperty, configurable));
+    JsValueRef configurable;
+    CHECK_JSRT(JsBoolToBoolean(!(p->attributes & napi_dont_delete), &configurable));
+    CHECK_JSRT(JsSetProperty(descriptor, configurableProperty, configurable, true));
 
-    napi_value enumerable;
-    CHECK_NAPI(napi_create_boolean(e, !(p->attributes & napi_dont_enum), &enumerable));
-    CHECK_NAPI(napi_set_property(e, descriptor, enumerableProperty, enumerable));
+    JsValueRef enumerable;
+    CHECK_JSRT(JsBoolToBoolean(!(p->attributes & napi_dont_enum), &enumerable));
+    CHECK_JSRT(JsSetProperty(descriptor, enumerableProperty, enumerable, true));
 
     if (p->method) {
-      napi_propertyname valueProperty;
-      CHECK_NAPI(napi_property_name(e, "value", &valueProperty));
-      napi_value method;
-      CHECK_NAPI(napi_create_function(e, p->method, p->data, &method));
-      CHECK_NAPI(napi_set_property(e, descriptor, valueProperty, method));
+      JsPropertyIdRef valueProperty;
+      CHECK_JSRT(JsCreatePropertyIdUtf8("value", 5, &valueProperty));
+      JsValueRef method;
+      CHECK_NAPI(napi_create_function(e, p->method, p->data,
+        reinterpret_cast<napi_value*>(&method)));
+      CHECK_JSRT(JsSetProperty(descriptor, valueProperty, method, true));
     }
     else if (p->getter || p->setter) {
       if (p->getter) {
-        napi_propertyname getProperty;
-        CHECK_NAPI(napi_property_name(e, "get", &getProperty));
-        napi_value getter;
-        CHECK_NAPI(napi_create_function(e, p->getter, p->data, &getter));
-        CHECK_NAPI(napi_set_property(e, descriptor, getProperty, getter));
+        JsPropertyIdRef getProperty;
+        CHECK_JSRT(JsCreatePropertyIdUtf8("get", 3, &getProperty));
+        JsValueRef getter;
+        CHECK_NAPI(napi_create_function(e, p->getter, p->data,
+          reinterpret_cast<napi_value*>(&getter)));
+        CHECK_JSRT(JsSetProperty(descriptor, getProperty, getter, true));
       }
 
       if (p->setter) {
-        napi_propertyname setProperty;
-        CHECK_NAPI(napi_property_name(e, "set", &setProperty));
-        napi_value setter;
-        CHECK_NAPI(napi_create_function(e, p->setter, p->data, &setter));
-        CHECK_NAPI(napi_set_property(e, descriptor, setProperty, setter));
+        JsPropertyIdRef setProperty;
+        CHECK_JSRT(JsCreatePropertyIdUtf8("set", 5, &setProperty));
+        JsValueRef setter;
+        CHECK_NAPI(napi_create_function(e, p->setter, p->data,
+          reinterpret_cast<napi_value*>(&setter)));
+        CHECK_JSRT(JsSetProperty(descriptor, setProperty, setter, true));
       }
     }
     else {
       RETURN_STATUS_IF_FALSE(p->value != nullptr, napi_invalid_arg);
 
-      napi_propertyname writableProperty;
-      CHECK_NAPI(napi_property_name(e, "writable", &writableProperty));
-      napi_value writable;
-      CHECK_NAPI(napi_create_boolean(e, !(p->attributes & napi_read_only), &writable));
-      CHECK_NAPI(napi_set_property(e, descriptor, writableProperty, writable));
+      JsPropertyIdRef writableProperty;
+      CHECK_JSRT(JsCreatePropertyIdUtf8("writable", 8, &writableProperty));
+      JsValueRef writable;
+      CHECK_JSRT(JsBoolToBoolean(!(p->attributes & napi_read_only), &writable));
+      CHECK_JSRT(JsSetProperty(descriptor, writableProperty, writable, true));
 
-      napi_propertyname valueProperty;
-      CHECK_NAPI(napi_property_name(e, "value", &valueProperty));
-      CHECK_NAPI(napi_set_property(e, descriptor, valueProperty, p->value));
+      JsPropertyIdRef valueProperty;
+      CHECK_JSRT(JsCreatePropertyIdUtf8("value", 5, &valueProperty));
+      CHECK_JSRT(JsSetProperty(descriptor, valueProperty,
+        reinterpret_cast<JsValueRef>(p->value), true));
     }
 
-    napi_propertyname nameProperty;
-    CHECK_NAPI(napi_property_name(e, p->utf8name, &nameProperty));
+    JsPropertyIdRef nameProperty;
+    CHECK_JSRT(JsCreatePropertyIdUtf8(p->utf8name, strlen(p->utf8name), &nameProperty));
     bool result;
     CHECK_JSRT(JsDefineProperty(
       reinterpret_cast<JsValueRef>(o),
@@ -727,7 +731,7 @@ napi_status napi_get_cb_args(napi_env e, napi_callback_info cbinfo,
   const CallbackInfo *info = reinterpret_cast<CallbackInfo*>(cbinfo);
 
   int i = 0;
-  int min = bufferlength < (info->argc) - 1 ? bufferlength : (info->argc) - 1;
+  int min = std::min(bufferlength, info->argc - 1);
 
   for (; i < min; i++) {
     buffer[i] = info->argv[i + 1];

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -186,8 +186,10 @@ NODE_EXTERN napi_status napi_has_element(napi_env e, napi_value object,
                                   uint32_t i, bool* result);
 NODE_EXTERN napi_status napi_get_element(napi_env e, napi_value object,
                                   uint32_t i, napi_value* result);
-NODE_EXTERN napi_status napi_define_property(napi_env e, napi_value object,
-                                  napi_property_descriptor* property);
+NODE_EXTERN napi_status napi_define_properties(napi_env e,
+                                               napi_value object,
+                                               int property_count,
+                                               const napi_property_descriptor* properties);
 
 // Methods to work with Arrays
 NODE_EXTERN napi_status napi_is_array(napi_env e, napi_value v, bool* result);
@@ -263,13 +265,13 @@ NODE_EXTERN napi_status napi_wrap(napi_env e, napi_value jsObject, void* nativeO
                                   napi_weakref* handle);
 NODE_EXTERN napi_status napi_unwrap(napi_env e, napi_value jsObject, void** result);
 
-NODE_EXTERN napi_status napi_create_constructor(napi_env e,
-                                                const char* utf8name,
-                                                napi_callback cb,
-                                                void* data,
-                                                int property_count,
-                                                napi_property_descriptor* properties,
-                                                napi_value* result);
+NODE_EXTERN napi_status napi_define_class(napi_env e,
+                                          const char* utf8name,
+                                          napi_callback constructor,
+                                          void* data,
+                                          int property_count,
+                                          const napi_property_descriptor* properties,
+                                          napi_value* result);
 
 // Methods to control object lifespan
 NODE_EXTERN napi_status napi_create_persistent(napi_env e, napi_value v,

--- a/src/node_jsvmapi_types.h
+++ b/src/node_jsvmapi_types.h
@@ -1,6 +1,7 @@
 ﻿#ifndef SRC_NODE_JSVMAPI_TYPES_H_
 #define SRC_NODE_JSVMAPI_TYPES_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 // JSVM API types are all opaque pointers for ABI stability
@@ -21,7 +22,11 @@ enum napi_property_attributes {
   napi_default = 0,
   napi_read_only = 1 << 0,
   napi_dont_enum = 1 << 1,
-  napi_dont_delete = 1 << 2
+  napi_dont_delete = 1 << 2,
+
+  // Used with napi_define_class to distinguish static properties
+  // from instance properties. Ignored by napi_define_properties.
+  napi_static_property = 1 << 10,
 };
 
 struct napi_property_descriptor {

--- a/test/addons-abi/1_hello_world/binding.cc
+++ b/test/addons-abi/1_hello_world/binding.cc
@@ -12,7 +12,7 @@ void Method(napi_env env, napi_callback_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
   napi_property_descriptor desc = { "hello", Method };
-  status = napi_define_property(env, exports, &desc);
+  status = napi_define_properties(env, exports, 1, &desc);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/2_function_arguments/binding.cc
+++ b/test/addons-abi/2_function_arguments/binding.cc
@@ -49,7 +49,7 @@ void Add(napi_env env, napi_callback_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
   napi_property_descriptor addDescriptor = { "add", Add };
-  status = napi_define_property(env, exports, &addDescriptor);
+  status = napi_define_properties(env, exports, 1, &addDescriptor);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/3_callbacks/binding.cc
+++ b/test/addons-abi/3_callbacks/binding.cc
@@ -41,10 +41,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "RunCallback", RunCallback },
     { "RunCallbackWithRecv", RunCallbackWithRecv }
   };
-  for (int index = 0; index < 2; index++) {
-    status = napi_define_property(env, exports, &desc[index]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(desc) / sizeof(napi_property_descriptor), desc);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/4_object_factory/binding.cc
+++ b/test/addons-abi/4_object_factory/binding.cc
@@ -25,7 +25,7 @@ void CreateObject(napi_env env, const napi_callback_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
   napi_property_descriptor desc = { "exports", CreateObject };
-  status = napi_define_property(env, module, &desc);
+  status = napi_define_properties(env, module, 1, &desc);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/5_function_factory/binding.cc
+++ b/test/addons-abi/5_function_factory/binding.cc
@@ -33,7 +33,7 @@ void CreateFunction(napi_env env, napi_callback_info info) {
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
   napi_property_descriptor desc = { "exports", CreateFunction };
-  status = napi_define_property(env, module, &desc);
+  status = napi_define_properties(env, module, 1, &desc);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/6_object_wrap/myobject.cc
+++ b/test/addons-abi/6_object_wrap/myobject.cc
@@ -21,7 +21,7 @@ void MyObject::Init(napi_env env, napi_value exports) {
   };
 
   napi_value cons;
-  status = napi_create_constructor(env, "MyObject", New, nullptr, 3, properties, &cons);
+  status = napi_define_class(env, "MyObject", New, nullptr, 3, properties, &cons);
   if (status != napi_ok) return;
 
   status = napi_create_persistent(env, cons, &constructor);

--- a/test/addons-abi/7_factory_wrap/binding.cc
+++ b/test/addons-abi/7_factory_wrap/binding.cc
@@ -22,7 +22,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   if (status != napi_ok) return;
 
   napi_property_descriptor desc = { "exports", CreateObject };
-  status = napi_define_property(env, module, &desc);
+  status = napi_define_properties(env, module, 1, &desc);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/7_factory_wrap/myobject.cc
+++ b/test/addons-abi/7_factory_wrap/myobject.cc
@@ -16,7 +16,7 @@ napi_status MyObject::Init(napi_env env) {
   };
 
   napi_value cons;
-  status = napi_create_constructor(env, "MyObject", New, nullptr, 1, properties, &cons);
+  status = napi_define_class(env, "MyObject", New, nullptr, 1, properties, &cons);
   if (status != napi_ok) return status;
 
   status = napi_create_persistent(env, cons, &constructor);

--- a/test/addons-abi/8_passing_wrapped/binding.cc
+++ b/test/addons-abi/8_passing_wrapped/binding.cc
@@ -42,12 +42,11 @@ void Init(napi_env env, napi_value exports, napi_value module) {
 
   MyObject::Init(env);
 
-  napi_property_descriptor desc = { "createObject", CreateObject };
-  status = napi_define_property(env, exports, &desc);
-  if (status != napi_ok) return;
-
-  napi_property_descriptor desc2 = { "add", Add };
-  status = napi_define_property(env, exports, &desc2);
+  napi_property_descriptor desc[] = {
+    { "createObject", CreateObject },
+    { "add", Add },
+  };
+  status = napi_define_properties(env, exports, sizeof(desc) / sizeof(*desc), desc);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/8_passing_wrapped/myobject.cc
+++ b/test/addons-abi/8_passing_wrapped/myobject.cc
@@ -14,7 +14,7 @@ napi_status MyObject::Init(napi_env env) {
   napi_status status;
 
   napi_value cons;
-  status = napi_create_constructor(env, "MyObject", New, nullptr, 0, nullptr, &cons);
+  status = napi_define_class(env, "MyObject", New, nullptr, 0, nullptr, &cons);
   if (status != napi_ok) return status;
 
   status = napi_create_persistent(env, cons, &constructor);

--- a/test/addons-abi/test_array/test_array.cc
+++ b/test/addons-abi/test_array/test_array.cc
@@ -128,10 +128,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "New", New },
   };
 
-  for (int i = 0; i < sizeof(descriptors) / sizeof(*descriptors); i++) {
-    status = napi_define_property(env, exports, &descriptors[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_constructor/test_constructor.cc
+++ b/test/addons-abi/test_constructor/test_constructor.cc
@@ -91,7 +91,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   };
 
   napi_value cons;
-  status = napi_create_constructor(env, "MyObject", New,
+  status = napi_define_class(env, "MyObject", New,
     nullptr, sizeof(properties)/sizeof(*properties), properties, &cons);
   if (status != napi_ok) return;
 

--- a/test/addons-abi/test_exception/test_exception.cc
+++ b/test/addons-abi/test_exception/test_exception.cc
@@ -65,10 +65,9 @@ NAPI_MODULE_INIT(Init) {
     { "wasPending", wasPending },
   };
 
-  for (int i = 0; i < sizeof(descriptors) / sizeof(*descriptors); i++) {
-    status = napi_define_property(env, exports, &descriptors[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_instanceof/test_instanceof.cc
+++ b/test/addons-abi/test_instanceof/test_instanceof.cc
@@ -28,10 +28,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "doInstanceOf", doInstanceOf },
   };
 
-  for (int i = 0; i < sizeof(descriptors) / sizeof(*descriptors); i++) {
-    status = napi_define_property(env, exports, &descriptors[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_number/test_number.cc
+++ b/test/addons-abi/test_number/test_number.cc
@@ -44,10 +44,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "Test", Test },
   };
 
-  for (int i = 0; i < sizeof(descriptors) / sizeof(*descriptors); i++) {
-    status = napi_define_property(env, exports, &descriptors[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_object/test_object.cc
+++ b/test/addons-abi/test_object/test_object.cc
@@ -224,10 +224,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "Inflate", Inflate },
   };
 
-  for (int i = 0; i < sizeof(descriptors) / sizeof(*descriptors); i++) {
-    status = napi_define_property(env, exports, &descriptors[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_properties/test_properties.cc
+++ b/test/addons-abi/test_properties/test_properties.cc
@@ -78,10 +78,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
       static_cast<napi_property_attributes>(napi_read_only | napi_dont_enum) },
   };
 
-  for (int i = 0; i < sizeof(properties) / sizeof(*properties); i++) {
-    status = napi_define_property(env, exports, &properties[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(properties) / sizeof(*properties), properties);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_string/test_string.cc
+++ b/test/addons-abi/test_string/test_string.cc
@@ -122,10 +122,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "Utf8Length", Utf8Length },
   };
 
-  for (int i = 0; i < sizeof(properties) / sizeof(*properties); i++) {
-    status = napi_define_property(env, exports, &properties[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(properties) / sizeof(*properties), properties);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_symbol/test_symbol.cc
+++ b/test/addons-abi/test_symbol/test_symbol.cc
@@ -87,10 +87,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "New", New },
   };
 
-  for (int i = 0; i < sizeof(properties) / sizeof(*properties); i++) {
-    status = napi_define_property(env, exports, &properties[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(properties) / sizeof(*properties), properties);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_typedarray/test_typedarray.cc
+++ b/test/addons-abi/test_typedarray/test_typedarray.cc
@@ -105,10 +105,9 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "Multiply", Multiply },
   };
 
-  for (int i = 0; i < sizeof(descriptors) / sizeof(*descriptors); i++) {
-    status = napi_define_property(env, exports, &descriptors[i]);
-    if (status != napi_ok) return;
-  }
+  status = napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);
+  if (status != napi_ok) return;
 }
 
 NODE_MODULE_ABI(addon, Init)


### PR DESCRIPTION
 - Rename napi_create_constructor to napi_define_class and include support for defining static properties on the class at the same time
 - Rename napi_define_property to napi_define_properties to allow for defining multiple properties at the same time
 - Update tests for the changes

Most of the files are copied from the [same change in the V8 branch](https://github.com/nodejs/abi-stable-node/pull/97), except for the JSRT implementation which is new.