### PR TITLE
Add finalize cb to external arraybuffer (V8)

### DIFF
--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -332,7 +332,9 @@ NODE_EXTERN napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool
 NODE_EXTERN napi_status napi_create_arraybuffer(napi_env env, size_t byte_length, void** data,
                                                 napi_value* result);
 NODE_EXTERN napi_status napi_create_external_arraybuffer(napi_env env, void* external_data,
-                                                         size_t byte_length, napi_value* result);
+                                                         size_t byte_length,
+                                                         napi_finalize finalize_cb,
+                                                         napi_value* result);
 NODE_EXTERN napi_status napi_get_arraybuffer_info(napi_env env, napi_value arraybuffer,
                                                   void** data, size_t* byte_length);
 NODE_EXTERN napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result);

--- a/test/addons-abi/test_typedarray/test.js
+++ b/test/addons-abi/test_typedarray/test.js
@@ -18,13 +18,22 @@ doubleArray[2] = 2.2;
 assert.equal(doubleArray.length, 3);
 
 var byteResult = test_typedarray.Multiply(byteArray, 3);
+assert.ok(byteResult instanceof Uint8Array);
 assert.equal(byteResult.length, 3);
 assert.equal(byteResult[0], 0);
 assert.equal(byteResult[1], 3);
 assert.equal(byteResult[2], 6);
 
 var doubleResult = test_typedarray.Multiply(doubleArray, -3);
+assert.ok(doubleResult instanceof Float64Array);
 assert.equal(doubleResult.length, 3);
 assert.equal(doubleResult[0], 0);
 assert.equal(Math.round(10 * doubleResult[1]) / 10, -3.3);
 assert.equal(Math.round(10 * doubleResult[2]) / 10, -6.6);
+
+var externalResult = test_typedarray.External();
+assert.ok(externalResult instanceof Int8Array);
+assert.equal(externalResult.length, 3);
+assert.equal(externalResult[0], 0);
+assert.equal(externalResult[1], 1);
+assert.equal(externalResult[2], 2);

--- a/test/addons-abi/test_typedarray/test_typedarray.cc
+++ b/test/addons-abi/test_typedarray/test_typedarray.cc
@@ -98,11 +98,29 @@ void Multiply(napi_env env, napi_callback_info info) {
   if (status != napi_ok) return;
 }
 
+void External(napi_env env, napi_callback_info info) {
+  static int8_t externalData[] = { 0, 1, 2 };
+
+  napi_value output_buffer;
+  napi_status status = napi_create_external_arraybuffer(
+    env, externalData, sizeof(externalData), nullptr, &output_buffer);
+  if (status != napi_ok) return;
+
+  napi_value output_array;
+  status = napi_create_typedarray(
+    env, napi_int8, sizeof(externalData) / sizeof(uint8_t), output_buffer, 0, &output_array);
+  if (status != napi_ok) return;
+
+  status = napi_set_return_value(env, info, output_array);
+  if (status != napi_ok) return;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {
     { "Multiply", Multiply },
+    { "External", External },
   };
 
   status = napi_define_properties(


### PR DESCRIPTION
We should support a finalize callback wherever an external data pointer is provided. This was an oversight in my TypedArray implementation.

I've also added a test case for the `napi_create_external_arraybuffer` API, though it doesn't use the finalize callback because it would be difficult to force the finalizer to be invoked during the test.