### PR TITLE
Reference and external improvements (ChakraCore)

### DIFF
--- a/src/node_api_helpers.h
+++ b/src/node_api_helpers.h
@@ -138,7 +138,7 @@ namespace Napi {
       HandleScope scope(env);
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &handle);
+      napi_create_reference(env, obj, 1, &handle);
     }
 
     explicit Callback(napi_value fn) {
@@ -147,7 +147,7 @@ namespace Napi {
       HandleScope scope(env);
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &handle);
+      napi_create_reference(env, obj, 1, &handle);
       SetFunction(fn);
     }
 
@@ -158,7 +158,7 @@ namespace Napi {
 
       napi_env env;
       napi_get_current_env(&env);
-      napi_release_persistent(env, handle);
+      napi_delete_reference(env, handle);
     }
 
     bool operator==(const Callback &other) const {
@@ -167,9 +167,9 @@ namespace Napi {
       napi_get_current_env(&env);
 
       napi_value ha;
-      napi_get_persistent_value(env, handle, &ha);
+      napi_get_reference_value(env, handle, &ha);
       napi_value hb;
-      napi_get_persistent_value(env, other.handle, &hb);
+      napi_get_reference_value(env, other.handle, &hb);
 
       napi_value a;
       napi_get_element(env, ha, kCallbackIndex, &a);
@@ -206,7 +206,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_set_element(env, h, kCallbackIndex, fn);
     }
 
@@ -215,7 +215,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
       return scope.Escape(fn);
@@ -226,7 +226,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
       napi_valuetype valuetype;
@@ -252,7 +252,7 @@ namespace Napi {
 
    private:
     NAPI_DISALLOW_ASSIGN_COPY_MOVE(Callback)
-    napi_persistent handle;
+    napi_ref handle;
     static const uint32_t kCallbackIndex = 0;
 
     napi_value Call_(napi_value target,
@@ -263,7 +263,7 @@ namespace Napi {
       napi_get_current_env(&env);
 
       napi_value h;
-      napi_get_persistent_value(env, handle, &h);
+      napi_get_reference_value(env, handle, &h);
       napi_value fn;
       napi_get_element(env, h, kCallbackIndex, &fn);
 
@@ -293,7 +293,7 @@ namespace Napi {
       HandleScope scope;
       napi_value obj;
       napi_create_object(env, &obj);
-      napi_create_persistent(env, obj, &persistentHandle);
+      napi_create_reference(env, obj, 1, &persistentHandle);
     }
 
     virtual ~AsyncWorker() {
@@ -302,7 +302,7 @@ namespace Napi {
       if (persistentHandle != NULL) {
         napi_env env;
         napi_get_current_env(&env);
-        napi_release_persistent(env, persistentHandle);
+        napi_delete_reference(env, persistentHandle);
         persistentHandle = NULL;
       }
       delete callback;
@@ -330,7 +330,7 @@ namespace Napi {
       napi_propertyname pnKey;
       napi_property_name(env, key, &pnKey);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_property(env, h, pnKey, value);
     }
 
@@ -340,7 +340,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_property(env, h, key, value);
     }
 
@@ -350,7 +350,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_set_element(env, h, index, value);
     }
 
@@ -361,7 +361,7 @@ namespace Napi {
       napi_propertyname pnKey;
       napi_property_name(env, key, &pnKey);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_property(env, h, pnKey, &v);
       return scope.Escape(v);
@@ -373,7 +373,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_property(env, h, key, &v);
       return scope.Escape(v);
@@ -384,7 +384,7 @@ namespace Napi {
       napi_env env;
       napi_get_current_env(&env);
       napi_value h;
-      napi_get_persistent_value(env, persistentHandle, &h);
+      napi_get_reference_value(env, persistentHandle, &h);
       napi_value v;
       napi_get_element(env, h, index, &v);
       return scope.Escape(v);
@@ -414,7 +414,7 @@ namespace Napi {
     }
 
    protected:
-    napi_persistent persistentHandle;
+    napi_ref persistentHandle;
     Callback *callback;
 
     virtual void HandleOKCallback() {

--- a/src/node_jsvmapi_types.h
+++ b/src/node_jsvmapi_types.h
@@ -8,15 +8,14 @@
 // typedef undefined structs instead of void* for compile time type safety
 typedef struct napi_env__ *napi_env;
 typedef struct napi_value__ *napi_value;
-typedef struct napi_persistent__ *napi_persistent;
-typedef struct napi_weakref__ *napi_weakref;
+typedef struct napi_ref__ *napi_ref;
 typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_propertyname__ *napi_propertyname;
 typedef struct napi_callback_info__ *napi_callback_info;
 
 typedef void (*napi_callback)(napi_env, napi_callback_info);
-typedef void (*napi_destruct)(void* v);
+typedef void (*napi_finalize)(void* v);
 
 enum napi_property_attributes {
   napi_default = 0,
@@ -51,6 +50,7 @@ enum napi_valuetype {
   napi_symbol,
   napi_object,
   napi_function,
+  napi_external,
 };
 
 enum napi_typedarray_type {

--- a/test/addons-abi/3_callbacks/binding.cc
+++ b/test/addons-abi/3_callbacks/binding.cc
@@ -41,8 +41,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
     { "RunCallback", RunCallback },
     { "RunCallbackWithRecv", RunCallbackWithRecv }
   };
-  status = napi_define_properties(
-    env, exports, sizeof(desc) / sizeof(napi_property_descriptor), desc);
+  status = napi_define_properties(env, exports, 2, desc);
   if (status != napi_ok) return;
 }
 

--- a/test/addons-abi/6_object_wrap/myobject.h
+++ b/test/addons-abi/6_object_wrap/myobject.h
@@ -17,8 +17,10 @@ class MyObject {
   static void SetValue(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   static void Multiply(napi_env env, napi_callback_info info);
-  static napi_persistent constructor;
+  static napi_ref constructor;
   double value_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_6_OBJECT_WRAP_MYOBJECT_H_

--- a/test/addons-abi/6_object_wrap/test.js
+++ b/test/addons-abi/6_object_wrap/test.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var addon = require('./build/Release/binding');
 
 var obj = new addon.MyObject(9);
+assert.ok(obj instanceof addon.MyObject);
 assert.equal(obj.value, 9);
 obj.value = 10;
 assert.equal(obj.value, 10);

--- a/test/addons-abi/7_factory_wrap/myobject.cc
+++ b/test/addons-abi/7_factory_wrap/myobject.cc
@@ -1,13 +1,16 @@
 #include "myobject.h"
 
-MyObject::MyObject() {}
-MyObject::~MyObject() {}
+MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
+
+MyObject::~MyObject() {
+    napi_delete_reference(env_, wrapper_);
+}
 
 void MyObject::Destructor(void* nativeObject) {
   reinterpret_cast<MyObject*>(nativeObject)->~MyObject();
 }
 
-napi_persistent MyObject::constructor;
+napi_ref MyObject::constructor;
 
 napi_status MyObject::Init(napi_env env) {
   napi_status status;
@@ -19,7 +22,7 @@ napi_status MyObject::Init(napi_env env) {
   status = napi_define_class(env, "MyObject", New, nullptr, 1, properties, &cons);
   if (status != napi_ok) return status;
 
-  status = napi_create_persistent(env, cons, &constructor);
+  status = napi_create_reference(env, cons, 1, &constructor);
   if (status != napi_ok) return status;
 
   return napi_ok;
@@ -50,8 +53,9 @@ void MyObject::New(napi_env env, napi_callback_info info) {
   status = napi_get_cb_this(env, info, &jsthis);
   if (status != napi_ok) return;
 
+  obj->env_ = env;
   status = napi_wrap(env, jsthis, reinterpret_cast<void*>(obj),
-                     MyObject::Destructor, nullptr);
+                     MyObject::Destructor, &obj->wrapper_);
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, jsthis);
@@ -66,7 +70,7 @@ napi_status MyObject::NewInstance(napi_env env, napi_value arg, napi_value* inst
   napi_value argv[argc] = { arg };
 
   napi_value cons;
-  status = napi_get_persistent_value(env, constructor, &cons);
+  status = napi_get_reference_value(env, constructor, &cons);
   if (status != napi_ok) return status;
 
   status = napi_new_instance(env, cons, argc, argv, instance);

--- a/test/addons-abi/7_factory_wrap/myobject.h
+++ b/test/addons-abi/7_factory_wrap/myobject.h
@@ -13,10 +13,12 @@ class MyObject {
   MyObject();
   ~MyObject();
 
-  static napi_persistent constructor;
+  static napi_ref constructor;
   static void New(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   double counter_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_7_FACTORY_WRAP_MYOBJECT_H_

--- a/test/addons-abi/8_passing_wrapped/myobject.h
+++ b/test/addons-abi/8_passing_wrapped/myobject.h
@@ -14,9 +14,11 @@ class MyObject {
   MyObject();
   ~MyObject();
 
-  static napi_persistent constructor;
+  static napi_ref constructor;
   static void New(napi_env env, napi_callback_info info);
   double val_;
+  napi_env env_;
+  napi_ref wrapper_;
 };
 
 #endif  // TEST_ADDONS_ABI_8_PASSING_WRAPPED_MYOBJECT_H_

--- a/test/addons-abi/test_constructor/test_constructor.cc
+++ b/test/addons-abi/test_constructor/test_constructor.cc
@@ -1,7 +1,7 @@
 #include <node_jsvmapi.h>
 
 static double value_ = 1;
-napi_persistent constructor_;
+napi_ref constructor_;
 
 void GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
@@ -102,7 +102,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   status = napi_set_property(env, module, name, cons);
   if (status != napi_ok) return;
 
-  status = napi_create_persistent(env, cons, &constructor_);
+  status = napi_create_reference(env, cons, 1, &constructor_);
   if (status != napi_ok) return;
 }
 


### PR DESCRIPTION
 - Add APIs for external values with data pointer & finalizer callback
 - Replace persistent and weak-ref types and APIs with unified counted-reference type and APIs
 - Update wrap/unwrap APIs to use reference type and avoid using the shim
 - Add finalize callback for external arraybuffer
 - Fix handling of data context for function callbacks

Note the changes in `node_jsvmapi.h`, `node_api_helpers.h`, and test files are just copied from [the equivalent change in the V8 branch](https://github.com/nodejs/abi-stable-node/pull/99).