### PR TITLE
Enable custom tagged binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,7 +549,7 @@ PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacO
 PKGDIR=out/dist-osx
 
 release-only:
-	@if [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
+	@if [ "$(DISTTYPE)" != "custom" ] && [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
 		`grep -q REPLACEME doc/api/*.md`; then \
 		echo 'Please update Added: tags in the documentation first.' ; \
 		exit 1 ; \


### PR DESCRIPTION
We need this change in the `Makefile` to enable custom-tagged builds for NAPI releases. Then when you run `node --version` with a NAPI build, it can output something like `v8.0.0-v8-napi-v0.1.0` or `v8.0.0-chakracore-napi-v0.1.0` rather than a nightly build tag.

From discussion with @aruneshchandra, as long as NAPI is a separate project from node we will version NAPI releases independently from the node version, because of how a single NAPI release includes builds of multiple node versions.

No equivalent change is needed for `vcbuild.bat` on Windows because it doesn't have this restriction for custom tagged builds.

I'm not sure whether this change would be included in an eventual PR to node. It seems generally correct to me to allow custom-tagged builds regardless of documentation status.