### PR TITLE
Revamp buffer API (ChakraCore)

### DIFF
--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -315,17 +315,21 @@ NODE_EXTERN napi_status napi_is_exception_pending(napi_env e, bool* result);
 NODE_EXTERN napi_status napi_get_and_clear_last_exception(napi_env e, napi_value* result);
 
 // Methods to provide node::Buffer functionality with napi types
-NODE_EXTERN napi_status napi_buffer_new(napi_env e,
-                                        char* data,
-                                        size_t size,
-                                        napi_value* result);
-NODE_EXTERN napi_status napi_buffer_copy(napi_env e,
-                                         const char* data,
-                                         size_t size,
-                                         napi_value* result);
-NODE_EXTERN napi_status napi_buffer_has_instance(napi_env e, napi_value v, bool* result);
-NODE_EXTERN napi_status napi_buffer_data(napi_env e, napi_value v, char** result);
-NODE_EXTERN napi_status napi_buffer_length(napi_env e, napi_value v, size_t* result);
+NODE_EXTERN napi_status napi_create_buffer(napi_env e,
+                                           size_t size,
+                                           char** data,
+                                           napi_value* result);
+NODE_EXTERN napi_status napi_create_external_buffer(napi_env e,
+                                                    size_t size,
+                                                    char* data,
+                                                    napi_finalize finalize_cb,
+                                                    napi_value* result);
+NODE_EXTERN napi_status napi_create_buffer_copy(napi_env e,
+                                                const char* data,
+                                                size_t size,
+                                                napi_value* result);
+NODE_EXTERN napi_status napi_is_buffer(napi_env e, napi_value v, bool* result);
+NODE_EXTERN napi_status napi_get_buffer_info(napi_env e, napi_value v, char** data, size_t* length);
 
 // Methods to work with array buffers and typed arrays
 NODE_EXTERN napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result);

--- a/test/addons-abi/1_hello_world/test.js
+++ b/test/addons-abi/1_hello_world/test.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 assert.equal(addon.hello(), 'world');

--- a/test/addons-abi/2_function_arguments/test.js
+++ b/test/addons-abi/2_function_arguments/test.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 assert.equal(addon.add(3, 5), 8);

--- a/test/addons-abi/3_callbacks/test.js
+++ b/test/addons-abi/3_callbacks/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 addon.RunCallback(function(msg) {
   assert.equal(msg, 'hello world');

--- a/test/addons-abi/4_object_factory/test.js
+++ b/test/addons-abi/4_object_factory/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 var obj1 = addon('hello');
 var obj2 = addon('world');

--- a/test/addons-abi/5_function_factory/test.js
+++ b/test/addons-abi/5_function_factory/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 var fn = addon();
 assert.equal(fn(), 'hello world'); // 'hello world'

--- a/test/addons-abi/6_object_wrap/test.js
+++ b/test/addons-abi/6_object_wrap/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 var obj = new addon.MyObject(9);
 assert.ok(obj instanceof addon.MyObject);

--- a/test/addons-abi/7_factory_wrap/test.js
+++ b/test/addons-abi/7_factory_wrap/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var createObject = require('./build/Release/binding');
+var createObject = require(`./build/${common.buildType}/binding`);
 
 var obj = createObject(10);
 assert.equal(obj.plusOne(), 11);

--- a/test/addons-abi/8_passing_wrapped/test.js
+++ b/test/addons-abi/8_passing_wrapped/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/binding');
+var addon = require(`./build/${common.buildType}/binding`);
 
 var obj1 = addon.createObject(10);
 var obj2 = addon.createObject(20);

--- a/test/addons-abi/test_array/test.js
+++ b/test/addons-abi/test_array/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // Testing api calls for arrays
-var test_array = require('./build/Release/test_array');
+var test_array = require(`./build/${common.buildType}/test_array`);
 
 var array = [
   1,

--- a/test/addons-abi/test_buffer/binding.gyp
+++ b/test/addons-abi/test_buffer/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_buffer",
+      "sources": [ "test_buffer.cc" ]
+    }
+  ]
+}

--- a/test/addons-abi/test_buffer/test.js
+++ b/test/addons-abi/test_buffer/test.js
@@ -1,0 +1,29 @@
+'use strict';
+// Flags: --expose-gc
+
+var common = require('../../common');
+var binding = require(`./build/${common.buildType}/test_buffer`);
+var assert = require( "assert" );
+
+assert( binding.newBuffer().toString() === binding.theText,
+  "buffer returned by newBuffer() has wrong contents" );
+assert( binding.newExternalBuffer().toString() === binding.theText,
+  "buffer returned by newExternalBuffer() has wrong contents" );
+
+setImmediate(() => {
+  global.gc();
+
+  assert( binding.getDeleterCallCount() == 1, "deleter was not called" );
+  assert( binding.copyBuffer().toString() === binding.theText,
+    "buffer returned by copyBuffer() has wrong contents" );
+
+  var buffer = binding.staticBuffer();
+  assert( binding.bufferHasInstance( buffer ), "buffer type checking fails" );
+  assert( binding.bufferInfo( buffer ), "buffer data is accurate" );
+
+  setImmediate(() => {
+    global.gc();
+
+    assert( binding.getDeleterCallCount() == 2, "deleter was not called" );
+  });
+});

--- a/test/addons-abi/test_buffer/test_buffer.cc
+++ b/test/addons-abi/test_buffer/test_buffer.cc
@@ -1,0 +1,128 @@
+#include <string.h>
+#include <string>
+#include <node_api_helpers.h>
+
+#define JS_ASSERT(env, assertion, message) \
+  if (!(assertion)) { \
+    napi_throw_error((env), (std::string("assertion (" #assertion ") failed: ") + message).c_str()); \
+    return; \
+  }
+
+#define NAPI_CALL(env, theCall) \
+  if (theCall != napi_ok) { \
+    const char *errorMessage = napi_get_last_error_info()->error_message; \
+    errorMessage = errorMessage ? errorMessage: "empty error message"; \
+    napi_throw_error((env), errorMessage); \
+    return; \
+  }
+
+static const char theText[] =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+static int deleterCallCount = 0;
+static void deleteTheText(void *data) {
+  delete (char *)data;
+  deleterCallCount++;
+}
+
+static void noopDeleter(void *data) {
+  deleterCallCount++;
+}
+
+NAPI_METHOD(newBuffer) {
+  napi_value theBuffer;
+  char *theCopy;
+  NAPI_CALL(env, napi_create_buffer(env, sizeof(theText), &theCopy,
+    &theBuffer));
+  JS_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
+  strcpy(theCopy, theText);
+  NAPI_CALL(env, napi_set_return_value(env, info, theBuffer));
+}
+
+NAPI_METHOD(newExternalBuffer) {
+  napi_value theBuffer;
+  char *theCopy = strdup(theText);
+  JS_ASSERT(env, theCopy,
+    "Failed to copy static text for newExternalBuffer");
+  NAPI_CALL(env, napi_create_external_buffer(env, sizeof(theText), theCopy,
+    deleteTheText, &theBuffer));
+  NAPI_CALL(env, napi_set_return_value(env, info, theBuffer));
+}
+
+NAPI_METHOD(getDeleterCallCount) {
+  napi_value callCount;
+  NAPI_CALL(env, napi_create_number(env, deleterCallCount, &callCount));
+  NAPI_CALL(env, napi_set_return_value(env, info, callCount));
+}
+
+NAPI_METHOD(copyBuffer) {
+  napi_value theBuffer;
+  NAPI_CALL(env, napi_create_buffer_copy(env, theText, sizeof(theText),
+    &theBuffer));
+  NAPI_CALL(env, napi_set_return_value(env, info, theBuffer));
+}
+
+NAPI_METHOD(bufferHasInstance) {
+  int argc;
+  NAPI_CALL(env, napi_get_cb_args_length(env, info, &argc));
+  JS_ASSERT(env, argc == 1, "Wrong number of arguments");
+  napi_value theBuffer;
+  NAPI_CALL(env, napi_get_cb_args(env, info, &theBuffer, 1));
+  bool hasInstance;
+  napi_valuetype theType;
+  NAPI_CALL(env, napi_get_type_of_value(env, theBuffer, &theType));
+  JS_ASSERT(env, theType == napi_object,
+    "bufferHasInstance: instance is not an object");
+  NAPI_CALL(env, napi_is_buffer(env, theBuffer, &hasInstance));
+  JS_ASSERT(env, hasInstance, "bufferHasInstance: instance is not a buffer");
+  napi_value returnValue;
+  NAPI_CALL(env, napi_create_boolean(env, hasInstance, &returnValue));
+  NAPI_CALL(env, napi_set_return_value(env, info, returnValue));
+}
+
+NAPI_METHOD(bufferInfo) {
+  int argc;
+  NAPI_CALL(env, napi_get_cb_args_length(env, info, &argc));
+  JS_ASSERT(env, argc == 1, "Wrong number of arguments");
+  napi_value theBuffer, returnValue;
+  NAPI_CALL(env, napi_get_cb_args(env, info, &theBuffer, 1));
+  char *bufferData;
+  size_t bufferLength;
+  NAPI_CALL(env, napi_get_buffer_info(env, theBuffer, &bufferData,
+    &bufferLength));
+  NAPI_CALL(env, napi_create_boolean(env,
+    !strcmp(bufferData, theText) && bufferLength == sizeof(theText),
+    &returnValue));
+  NAPI_CALL(env, napi_set_return_value(env, info, returnValue));
+}
+
+NAPI_METHOD(staticBuffer) {
+  napi_value theBuffer;
+  NAPI_CALL(env, napi_create_external_buffer(env, sizeof(theText),
+    (char *)theText, noopDeleter, &theBuffer));
+  NAPI_CALL(env, napi_set_return_value(env, info, theBuffer));
+}
+
+void Init(napi_env env, napi_value exports, napi_value module) {
+  napi_propertyname propName;
+  napi_value theValue;
+
+  NAPI_CALL(env, napi_property_name(env, "theText", &propName));
+  NAPI_CALL(env, napi_create_string_utf8(env, theText, sizeof(theText), &theValue));
+  NAPI_CALL(env, napi_set_property(env, exports, propName, theValue));
+
+  napi_property_descriptor methods[] = {
+    { "newBuffer", newBuffer },
+    { "newExternalBuffer", newExternalBuffer },
+    { "getDeleterCallCount", getDeleterCallCount },
+    { "copyBuffer", copyBuffer },
+    { "bufferHasInstance", bufferHasInstance },
+    { "bufferInfo", bufferInfo },
+    { "staticBuffer", staticBuffer }
+  };
+
+  NAPI_CALL(env, napi_define_properties(env, exports,
+    sizeof(methods)/sizeof(methods[0]), methods));
+}
+
+NODE_MODULE_ABI(addon, Init)

--- a/test/addons-abi/test_constructor/test.js
+++ b/test/addons-abi/test_constructor/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // Testing api calls for a constructor that defines properties
-var TestConstructor = require('./build/Release/test_constructor');
+var TestConstructor = require(`./build/${common.buildType}/test_constructor`);
 var test_object = new TestConstructor();
 
 assert.equal(test_object.echo('hello'), 'hello');

--- a/test/addons-abi/test_exception/test.js
+++ b/test/addons-abi/test_exception/test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var test_exception = require( "./build/Release/test_exception" );
+var common = require('../../common');
+var test_exception = require(`./build/${common.buildType}/test_exception`);
 var assert = require( "assert" );
 var theError = new Error( "Some error" );
 var throwTheError = function() {

--- a/test/addons-abi/test_function/test.js
+++ b/test/addons-abi/test_function/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // testing api calls for function
-var test_function = require('./build/Release/test_function');
+var test_function = require(`./build/${common.buildType}/test_function`);
 
 
 function func1() {

--- a/test/addons-abi/test_instanceof/test.js
+++ b/test/addons-abi/test_instanceof/test.js
@@ -1,8 +1,8 @@
 var fs = require( 'fs' );
 
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var addon = require('./build/Release/test_instanceof');
+var addon = require(`./build/${common.buildType}/test_instanceof`);
 var path = require( 'path' );
 
 function assertTrue(assertion) {

--- a/test/addons-abi/test_number/test.js
+++ b/test/addons-abi/test_number/test.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
-var test_number = require('./build/Release/test_number');
+var test_number = require(`./build/${common.buildType}/test_number`);
 
 
 // testing api calls for number

--- a/test/addons-abi/test_object/test.js
+++ b/test/addons-abi/test_object/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // Testing api calls for objects
-var test_object = require('./build/Release/test_object');
+var test_object = require(`./build/${common.buildType}/test_object`);
 
 
 var object = {

--- a/test/addons-abi/test_properties/test.js
+++ b/test/addons-abi/test_properties/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // Testing api calls for defining properties
-var test_object = require('./build/Release/test_properties');
+var test_object = require(`./build/${common.buildType}/test_properties`);
 
 assert.equal(test_object.echo('hello'), 'hello');
 

--- a/test/addons-abi/test_string/test.js
+++ b/test/addons-abi/test_string/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // testing api calls for string
-var test_string = require('./build/Release/test_string');
+var test_string = require(`./build/${common.buildType}/test_string`);
 
 var str1 = 'hello world';
 assert.equal(test_string.Copy(str1), str1);

--- a/test/addons-abi/test_symbol/test1.js
+++ b/test/addons-abi/test_symbol/test1.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // testing api calls for symbol
-var test_symbol = require('./build/Release/test_symbol');
+var test_symbol = require(`./build/${common.buildType}/test_symbol`);
 
 var sym = test_symbol.New('test');
 assert.equal(sym.toString(), 'Symbol(test)');

--- a/test/addons-abi/test_symbol/test2.js
+++ b/test/addons-abi/test_symbol/test2.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // testing api calls for symbol
-var test_symbol = require('./build/Release/test_symbol');
+var test_symbol = require(`./build/${common.buildType}/test_symbol`);
 
 var fooSym = test_symbol.New('foo');
 var myObj = {};

--- a/test/addons-abi/test_symbol/test3.js
+++ b/test/addons-abi/test_symbol/test3.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // testing api calls for symbol
-var test_symbol = require('./build/Release/test_symbol');
+var test_symbol = require(`./build/${common.buildType}/test_symbol`);
 
 assert.notEqual(test_symbol.New(), test_symbol.New());
 assert.notEqual(test_symbol.New('foo'), test_symbol.New('foo'));

--- a/test/addons-abi/test_typedarray/test.js
+++ b/test/addons-abi/test_typedarray/test.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 
 // Testing api calls for arrays
-var test_typedarray = require('./build/Release/test_typedarray');
+var test_typedarray = require(`./build/${common.buildType}/test_typedarray`);
 
 var byteArray = new Uint8Array(3);
 byteArray[0] = 0;
@@ -18,13 +18,22 @@ doubleArray[2] = 2.2;
 assert.equal(doubleArray.length, 3);
 
 var byteResult = test_typedarray.Multiply(byteArray, 3);
+assert.ok(byteResult instanceof Uint8Array);
 assert.equal(byteResult.length, 3);
 assert.equal(byteResult[0], 0);
 assert.equal(byteResult[1], 3);
 assert.equal(byteResult[2], 6);
 
 var doubleResult = test_typedarray.Multiply(doubleArray, -3);
+assert.ok(doubleResult instanceof Float64Array);
 assert.equal(doubleResult.length, 3);
 assert.equal(doubleResult[0], 0);
 assert.equal(Math.round(10 * doubleResult[1]) / 10, -3.3);
 assert.equal(Math.round(10 * doubleResult[2]) / 10, -6.6);
+
+var externalResult = test_typedarray.External();
+assert.ok(externalResult instanceof Int8Array);
+assert.equal(externalResult.length, 3);
+assert.equal(externalResult[0], 0);
+assert.equal(externalResult[1], 1);
+assert.equal(externalResult[2], 2);

--- a/test/addons-abi/test_typedarray/test_typedarray.cc
+++ b/test/addons-abi/test_typedarray/test_typedarray.cc
@@ -98,11 +98,29 @@ void Multiply(napi_env env, napi_callback_info info) {
   if (status != napi_ok) return;
 }
 
+void External(napi_env env, napi_callback_info info) {
+  static int8_t externalData[] = { 0, 1, 2 };
+
+  napi_value output_buffer;
+  napi_status status = napi_create_external_arraybuffer(
+    env, externalData, sizeof(externalData), nullptr, &output_buffer);
+  if (status != napi_ok) return;
+
+  napi_value output_array;
+  status = napi_create_typedarray(
+    env, napi_int8, sizeof(externalData) / sizeof(uint8_t), output_buffer, 0, &output_array);
+  if (status != napi_ok) return;
+
+  status = napi_set_return_value(env, info, output_array);
+  if (status != napi_ok) return;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {
     { "Multiply", Multiply },
+    { "External", External },
   };
 
   status = napi_define_properties(


### PR DESCRIPTION
This is the ChakraCore equivalent of the buffer API changes implemented for V8 as #109 and discussed as #108.

Changes to test files are copied directly from the V8 branch, so those don't need to be re-reviewed.
