### PR TITLE
Fix weakref callback for wrap (V8)

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -147,7 +147,12 @@ namespace v8impl {
         _finalizeCallback(finalizeCallback),
         _finalizeData(finalizeData) {
       if (initialRefcount == 0) {
-        _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        if (_finalizeCallback != nullptr || _deleteSelf) {
+          _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        }
+        else {
+          _persistent.SetWeak();
+        }
         _persistent.MarkIndependent();
       }
     }
@@ -172,7 +177,12 @@ namespace v8impl {
 
     int Release() {
       if (--_refcount == 0) {
-        _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        if (_finalizeCallback != nullptr || _deleteSelf) {
+          _persistent.SetWeak(this, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        }
+        else {
+          _persistent.SetWeak();
+        }
         _persistent.MarkIndependent();
       }
 
@@ -721,7 +731,7 @@ napi_status napi_define_class(
     }
 
     napi_status status = napi_define_properties(
-      e, *result, staticDescriptors.size(), staticDescriptors.data());
+      e, *result, static_cast<int>(staticDescriptors.size()), staticDescriptors.data());
     if (status != napi_ok) return status;
   }
 


### PR DESCRIPTION
This fixes a subtle bug related to V8 Persistent weakref callbacks that NAPI uses for object wrapping. The bug was caused by [a late change I made in the references PR](https://github.com/nodejs/abi-stable-node/pull/99#discussion_r100848875) that I neglected to stress-test. I found the bug today when trying to re-run the Canvas benchmarks after that change.

The feedback in the review was valid, and I'm keeping the change that was made there, just with an extra check to fix the bug. This is a complex issue that is difficult to explain. Here's an overview of the sequence that leads to the bug:

1. `napi_wrap` is called. It creates two `v8impl::Reference` instances, which each wrap a *weak* `v8::Persistent`. The Reference wrapping Persistent A is for internal tracking of the caller's finalize callback. The Reference wrapping Persistent B is returned by `napi_wrap`, to be held as a field in the ObjectWrap instance and used for refcounting across native async code.
2. (Some work is done by the wrapped object. All references to the object are eventually released and the object is ready to be GC'd.)
3. A and B weakref callbacks are added to V8's finalize queue.
4. Persistent A weakref callback is invoked.
5. That invokes ObjectWrap's finalizer callback.
6. That deletes the ObjectWrap instance.
7. The ObjectWrap instance destructor deletes its field Reference B
8. Reference B's desctructor resets its Persistent B.
9. The ObjectWrap finalizer callback returns.
10. The Persistent A weakref callback continues, and deletes Reference A.
11. Reference A's destructor resets its Persistent A.
12. Meanwhile Persistent B's weakref callback is still on the finalize queue.
13. Persistent B's weakref callback CRASHES when trying to dereference its data pointer because Reference B was already deleted.

The fix prevents registration of a weakref callback when the callback doesn't need to do anything anyway, as is the case for Reference B. Therefore it isn't a problem to delete Reference B from Persistent A's weakref callback.