### PR TITLE
napi_is_buffer should not return an error code when it's called with a non-TypedArray object

### DIFF
--- a/src/node_jsrtapi.cc
+++ b/src/node_jsrtapi.cc
@@ -1365,7 +1365,7 @@ napi_status napi_is_buffer(napi_env e, napi_value v, bool* result) {
     return napi_ok;
   }
   JsTypedArrayType arrayType;
-  JsErrorCode code = JsGetTypedArrayInfo(typedArray, &arrayType, nullptr, nullptr, nullptr);
+  CHECK_JSRT(JsGetTypedArrayInfo(typedArray, &arrayType, nullptr, nullptr, nullptr));
   *result = (arrayType == JsArrayTypeUint8);
   return napi_ok;
 }

--- a/src/node_jsrtapi.cc
+++ b/src/node_jsrtapi.cc
@@ -1358,8 +1358,14 @@ napi_status napi_create_buffer_copy(napi_env e,
 napi_status napi_is_buffer(napi_env e, napi_value v, bool* result) {
   CHECK_ARG(result);
   JsValueRef typedArray = reinterpret_cast<JsValueRef>(v);
+  JsValueType objectType;
+  CHECK_JSRT(JsGetValueType(typedArray, &objectType));
+  if (objectType != JsTypedArray) {
+    *result = false;
+    return napi_ok;
+  }
   JsTypedArrayType arrayType;
-  CHECK_JSRT(JsGetTypedArrayInfo(typedArray, &arrayType, nullptr, nullptr, nullptr));
+  JsErrorCode code = JsGetTypedArrayInfo(typedArray, &arrayType, nullptr, nullptr, nullptr);
   *result = (arrayType == JsArrayTypeUint8);
   return napi_ok;
 }


### PR DESCRIPTION
This is currently returning invalid argument which breaks most of the return-check macros we're using. The api napi_is_buffer should return false with no error if it's called with a non-TypedArray object.