### PR TITLE
Remove napi registration code from node.cc (V8)

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2430,15 +2430,24 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
 
   if (mp->nm_version != NODE_MODULE_VERSION) {
     char errmsg[1024];
-    snprintf(errmsg,
-             sizeof(errmsg),
-             "The module '%s'"
-             "\nwas compiled against a different Node.js version using"
-             "\nNODE_MODULE_VERSION %d. This version of Node.js requires"
-             "\nNODE_MODULE_VERSION %d. Please try re-compiling or "
-             "re-installing\nthe module (for instance, using `npm rebuild` or "
-             "`npm install`).",
-             *filename, mp->nm_version, NODE_MODULE_VERSION);
+    if (mp->nm_version == -1) {
+      snprintf(errmsg,
+               sizeof(errmsg),
+               "The module '%s'"
+               "\nwas compiled against the Node.js API. This feature is "
+               "\nexperimental and must be enabled on the command-line.",
+               *filename);
+    } else {
+      snprintf(errmsg,
+               sizeof(errmsg),
+               "The module '%s'"
+               "\nwas compiled against a different Node.js version using"
+               "\nNODE_MODULE_VERSION %d. This version of Node.js requires"
+               "\nNODE_MODULE_VERSION %d. Please try re-compiling or "
+               "re-installing\nthe module (for instance, using `npm rebuild` or "
+               "`npm install`).",
+               *filename, mp->nm_version, NODE_MODULE_VERSION);
+    }
 
     // NOTE: `mp` is allocated inside of the shared library's memory, calling
     // `uv_dlclose` will deallocate it

--- a/src/node.cc
+++ b/src/node.cc
@@ -1,4 +1,4 @@
-﻿#include "node.h"
+#include "node.h"
 #include "node_buffer.h"
 #include "node_constants.h"
 #include "node_file.h"

--- a/src/node.cc
+++ b/src/node.cc
@@ -1,4 +1,4 @@
-#include "node.h"
+﻿#include "node.h"
 #include "node_buffer.h"
 #include "node_constants.h"
 #include "node_file.h"
@@ -2428,13 +2428,7 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-#ifdef ENABLE_NAPI
-  bool isNapiModule = (!no_napi_modules && mp->nm_version == -1);
-
-  if (mp->nm_version != NODE_MODULE_VERSION && !isNapiModule) {
-#else /* !defined ENABLE_NAPI */
   if (mp->nm_version != NODE_MODULE_VERSION) {
-#endif /* def ENABLE_NAPI */
     char errmsg[1024];
     snprintf(errmsg,
              sizeof(errmsg),
@@ -2465,21 +2459,6 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Local<String> exports_string = env->exports_string();
   Local<Object> exports = module->Get(exports_string)->ToObject(env->isolate());
 
-#ifdef ENABLE_NAPI
-  if (isNapiModule) {
-    if (mp->nm_register_func != nullptr) {
-      reinterpret_cast<node::addon_abi_register_func>(mp->nm_register_func)(
-          v8impl::JsEnvFromV8Isolate(v8::Isolate::GetCurrent()),
-          v8impl::JsValueFromV8LocalValue(exports),
-          v8impl::JsValueFromV8LocalValue(module),
-          mp->nm_priv);
-    } else {
-      uv_dlclose(&lib);
-      env->ThrowError("Module has no declared entry point.");
-    }
-    return;
-  }
-#endif /* def ENABLE_NAPI */
   if (mp->nm_context_register_func != nullptr) {
     mp->nm_context_register_func(exports, module, env->context(), mp->nm_priv);
   } else if (mp->nm_register_func != nullptr) {
@@ -2714,19 +2693,7 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
                                   env->context(),
                                   mod->nm_priv);
   } else if (mod->nm_register_func != nullptr) {
-#ifdef ENABLE_NAPI
-    if (mod->nm_version != -1) {
-      mod->nm_register_func(exports, module, mod->nm_priv);
-    } else {
-      reinterpret_cast<node::addon_abi_register_func>(mod->nm_register_func)(
-          v8impl::JsEnvFromV8Isolate(v8::Isolate::GetCurrent()),
-          v8impl::JsValueFromV8LocalValue(exports),
-          v8impl::JsValueFromV8LocalValue(module),
-          mod->nm_priv);
-    }
-#else /* !defined ENABLE_NAPI */
     mod->nm_register_func(exports, module, mod->nm_priv);
-#endif /* def ENABLE_NAPI */
   } else {
     return env->ThrowError("Linked module has no declared entry point.");
   }

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -19,10 +19,6 @@
 #include <node_object_wrap.h>
 #include <vector>
 #include <string.h>
-
-void napi_module_register(void* mod) {
-  node::node_module_register(mod);
-}
 
 namespace v8impl {
 
@@ -495,6 +491,48 @@ namespace v8impl {
   }
 
 }  // end of namespace v8impl
+
+// Intercepts the Node-V8 module registration callback. Converts parameters to NAPI equivalents
+// and then calls the registration callback specified by the NAPI module.
+void napi_module_register_cb(v8::Local<v8::Object> exports,
+                             v8::Local<v8::Value> module,
+                             v8::Local<v8::Context> context,
+                             void* priv) {
+  napi_module* mod = static_cast<napi_module*>(priv);
+  mod->nm_register_func(
+    v8impl::JsEnvFromV8Isolate(context->GetIsolate()),
+    v8impl::JsValueFromV8LocalValue(exports),
+    v8impl::JsValueFromV8LocalValue(module),
+    mod->nm_priv);
+}
+
+namespace node {
+  // Indicates whether NAPI was enabled/disabled via the node command-line.
+  extern bool no_napi_modules;
+}
+
+// Registers a NAPI module.
+void napi_module_register(napi_module* mod) {
+  // NAPI modules always work with the current node version.
+  int moduleVersion = NODE_MODULE_VERSION;
+  if (node::no_napi_modules) {
+    // NAPI is dsabled, so set the module version to -1 to cause the module to be unloaded.
+    moduleVersion = -1;
+  }
+
+  static node::node_module nm = {
+    moduleVersion,
+    mod->nm_flags,
+    nullptr,
+    mod->nm_filename,
+    nullptr,
+    napi_module_register_cb,
+    mod->nm_modname,
+    mod, // priv
+    nullptr,
+  };
+  node::node_module_register(&nm);
+}
 
 #define RETURN_STATUS_IF_FALSE(condition, status)                       \
   do {                                                                  \

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -520,7 +520,7 @@ void napi_module_register(napi_module* mod) {
     moduleVersion = -1;
   }
 
-  static node::node_module nm = {
+  node::node_module* nm = new node::node_module {
     moduleVersion,
     mod->nm_flags,
     nullptr,
@@ -531,7 +531,7 @@ void napi_module_register(napi_module* mod) {
     mod, // priv
     nullptr,
   };
-  node::node_module_register(&nm);
+  node::node_module_register(nm);
 }
 
 #define RETURN_STATUS_IF_FALSE(condition, status)                       \

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -516,7 +516,7 @@ void napi_module_register(napi_module* mod) {
   // NAPI modules always work with the current node version.
   int moduleVersion = NODE_MODULE_VERSION;
   if (node::no_napi_modules) {
-    // NAPI is dsabled, so set the module version to -1 to cause the module to be unloaded.
+    // NAPI is disabled, so set the module version to -1 to cause the module to be unloaded.
     moduleVersion = -1;
   }
 

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -31,19 +31,15 @@ NODE_EXTERN typedef void (*addon_abi_register_func)(
   void* priv);
 }  // namespace node
 
-struct napi_module_struct {
-  int nm_version;
+struct napi_module {
   unsigned int nm_flags;
-  void* nm_dso_handle;
   const char* nm_filename;
   node::addon_abi_register_func nm_register_func;
-  void* nm_context_register_func;
   const char* nm_modname;
   void* nm_priv;
-  void* nm_link;
 };
 
-NODE_EXTERN void napi_module_register(void* mod);
+NODE_EXTERN void napi_module_register(napi_module* mod);
 
 #if defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
@@ -60,17 +56,13 @@ NODE_EXTERN void napi_module_register(void* mod);
 
 #define NODE_MODULE_ABI_X(modname, regfunc, priv, flags)              \
   extern "C" {                                                        \
-    static napi_module_struct _module =                               \
+    static napi_module _module =                                      \
     {                                                                 \
-      -1,                                                             \
       flags,                                                          \
-      NULL,                                                           \
       __FILE__,                                                       \
       (node::addon_abi_register_func)regfunc,                         \
-      NULL,                                                           \
       #modname,                                                       \
       priv,                                                           \
-      NULL                                                            \
     };                                                                \
     NODE_ABI_CTOR(_register_ ## modname) {                            \
       napi_module_register(&_module);                                 \

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -32,12 +32,16 @@ NODE_EXTERN typedef void (*addon_abi_register_func)(
 }  // namespace node
 
 struct napi_module {
+  int nm_version;
   unsigned int nm_flags;
   const char* nm_filename;
   node::addon_abi_register_func nm_register_func;
   const char* nm_modname;
   void* nm_priv;
+  void* reserved[4];
 };
+
+#define NAPI_MODULE_VERSION  1
 
 #if defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
@@ -56,11 +60,13 @@ struct napi_module {
   extern "C" {                                                        \
     static napi_module _module =                                      \
     {                                                                 \
+      NAPI_MODULE_VERSION,                                            \
       flags,                                                          \
       __FILE__,                                                       \
       (node::addon_abi_register_func)regfunc,                         \
       #modname,                                                       \
       priv,                                                           \
+      {0},                                                            \
     };                                                                \
     NODE_ABI_CTOR(_register_ ## modname) {                            \
       napi_module_register(&_module);                                 \

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -39,8 +39,6 @@ struct napi_module {
   void* nm_priv;
 };
 
-NODE_EXTERN void napi_module_register(napi_module* mod);
-
 #if defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
 #define NODE_ABI_CTOR(fn)                                             \
@@ -73,9 +71,9 @@ NODE_EXTERN void napi_module_register(napi_module* mod);
   NODE_MODULE_ABI_X(modname, regfunc, NULL, 0)
 
 
-// TODO(ianhall): We're using C linkage for the API but we're also using the
-// bool type in these exports.  Is that safe and stable?
 extern "C" {
+
+NODE_EXTERN void napi_module_register(napi_module* mod);
 
 NODE_EXTERN const napi_extended_error_info* napi_get_last_error_info();
 


### PR DESCRIPTION
I realized that it is possible to register NAPI modules without any NAPI-specific registration code in `node.cc`. This will make our diff much smaller in the eventual PR, and eliminate any possible concerns about a behavior change for "corrupt" modules having a version of -1.

Previously, `napi_module_register()` would simply forward the module struct unmodified to `node_module_register`. With this change it sets the module version to the current `NODE_MODULE_VERSION` (instead of -1). And it intercepts the registration callback in order to convert the `env`, `module` and `exports` objects to VM-agnostic types.

Also note NAPI is now using the "context-aware" module registration function (available in Node >= 4.0) to get the isolate from the context rather than calling `Isolate::GetCurrent()`.

Now the only NAPI-specific code in `node.cc` is for the command-line flag. (I think we plan to invert that, but I'll leave it for a later change.)