### PR TITLE
Distinguish external value type from wrapped (ChakraCore)

### DIFF
--- a/test/addons-abi/6_object_wrap/myobject.cc
+++ b/test/addons-abi/6_object_wrap/myobject.cc
@@ -19,10 +19,12 @@ void MyObject::Init(napi_env env, napi_value exports) {
     { "value", nullptr, GetValue, SetValue },
     { "plusOne", PlusOne },
     { "multiply", Multiply },
+    { "isInstance", IsInstance },
   };
 
   napi_value cons;
-  status = napi_define_class(env, "MyObject", New, nullptr, 3, properties, &cons);
+  status = napi_define_class(
+    env, "MyObject", New, nullptr, sizeof (properties) / sizeof (*properties), properties, &cons);
   if (status != napi_ok) return;
 
   status = napi_create_reference(env, cons, 1, &constructor);
@@ -193,5 +195,34 @@ void MyObject::Multiply(napi_env env, napi_callback_info info) {
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, instance);
+  if (status != napi_ok) return;
+}
+
+void MyObject::IsInstance(napi_env env, napi_callback_info info) {
+  napi_status status;
+
+  napi_value jsthis;
+  status = napi_get_cb_this(env, info, &jsthis);
+  if (status != napi_ok) return;
+
+  napi_valuetype valuetype;
+  status = napi_get_type_of_value(env, jsthis, &valuetype);
+  if (status != napi_ok) return;
+
+  bool result = false;
+  if (valuetype == napi_object) {
+    napi_value constructorFunction;
+    status = napi_get_reference_value(env, constructor, &constructorFunction);
+    if (status != napi_ok) return;
+
+    status = napi_instanceof(env, jsthis, constructorFunction, &result);
+    if (status != napi_ok) return;
+  }
+
+  napi_value resultValue;
+  status = napi_create_boolean(env, result, &resultValue);
+  if (status != napi_ok) return;
+
+  status = napi_set_return_value(env, info, resultValue);
   if (status != napi_ok) return;
 }

--- a/test/addons-abi/6_object_wrap/myobject.h
+++ b/test/addons-abi/6_object_wrap/myobject.h
@@ -17,6 +17,7 @@ class MyObject {
   static void SetValue(napi_env env, napi_callback_info info);
   static void PlusOne(napi_env env, napi_callback_info info);
   static void Multiply(napi_env env, napi_callback_info info);
+  static void IsInstance(napi_env env, napi_callback_info info);
   static napi_ref constructor;
   double value_;
   napi_env env_;

--- a/test/addons-abi/6_object_wrap/test.js
+++ b/test/addons-abi/6_object_wrap/test.js
@@ -18,3 +18,5 @@ assert.equal(obj.multiply(10).value, 130);
 var newobj = obj.multiply(-1);
 assert.equal(newobj.value, -13);
 assert(obj !== newobj);
+
+assert.ok(obj.isInstance());


### PR DESCRIPTION
This fixes a bug in the JSRT implementation of the NAPI "external" value type. Because JSRT doesn't actually have an external type (like V8 does), an external value is represented as an object with external data. But there needs to be some way to distinguish external values from wrapped objects, which also have external data. The solution is to set the external value object as not-extensible. That more closely matches the V8 implementation anyway because V8 external values cannot have properties.

This change includes a test case that failed before the fix and now passes.