### PR TITLE
Performance optimizations (V8)

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -1743,13 +1743,13 @@ napi_status napi_create_reference(napi_env e,
 // Deletes a reference. The referenced value is released, and may be GC'd unless there
 // are other references to it.
 napi_status napi_delete_reference(napi_env e, napi_ref ref) {
-  NAPI_PREAMBLE(e);
+  // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw JS exceptions.
   CHECK_ARG(ref);
 
   v8impl::Reference* reference = reinterpret_cast<v8impl::Reference*>(ref);
   delete reference;
 
-  return GET_RETURN_STATUS();
+  return napi_ok;
 }
 
 // Increments the reference count, optionally returning the resulting count. After this call the

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -210,6 +210,17 @@ NODE_EXTERN napi_status napi_make_callback(napi_env e,
                                            napi_value* result);
 
 // Methods to work with napi_callbacks
+
+// Gets all callback info in a single call. (Ugly, but faster.)
+NODE_EXTERN napi_status napi_get_cb_info(
+  napi_env e,                // [in] NAPI environment handle
+  napi_callback_info cbinfo, // [in] Opaque callback-info handle
+  int* argc,                 // [in-out] Specifies the size of the provided argv array
+                             // and receives the actual count of args.
+  napi_value* argv,          // [out] Array of values
+  napi_value* thisArg,       // [out] Receives the JS 'this' arg for the call
+  void** data);              // [out] Receives the data pointer for the callback.
+
 NODE_EXTERN napi_status napi_get_cb_args_length(napi_env e,
                                   napi_callback_info cbinfo, int* result);
 NODE_EXTERN napi_status napi_get_cb_args(napi_env e, napi_callback_info cbinfo,


### PR DESCRIPTION
 - Add a `napi_get_cb_info` function to get args length, args, this, and data in a single call
 - Move the static exception to a class member to enable inlining of the `lastException()` method.
 - Refactor the `CallbackWrapper` group of helper classes to avoid most (non-inlinable) virtual function calls
 - Remove use of `v8::TryCatch` (via `NAPI_PREAMBLE`) from several places where it shouldn't be needed.

Together, these optimizations reduce the overhead of every JS-to-C++ call through the NAPI layer by approximately 50%.