### PR TITLE
napi: Remove napi_set_function_name since not all engines can rename functions

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -644,9 +644,9 @@ napi_status napi_get_current_env(napi_env* e) {
 
 napi_status napi_create_function(
     napi_env e,
+    const char* utf8name,
     napi_callback cb,
     void* data,
-    const char* utf8name,
     napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -646,7 +646,7 @@ napi_status napi_create_function(
     napi_env e,
     napi_callback cb,
     void* data,
-    napi_propertyname name,
+    const char* utf8name,
     napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -666,10 +666,11 @@ napi_status napi_create_function(
     isolate, v8impl::FunctionCallbackWrapper::Invoke, cbdata);
 
   retval = scope.Escape(tpl->GetFunction());
-
-  if (name) {
-    v8::Local<v8::String> n = v8impl::V8LocalStringFromJsPropertyName(name);
-    retval->SetName(n);
+  
+  if (utf8name) {
+    v8::Local<v8::String> namestring;
+    CHECK_NEW_FROM_UTF8(isolate, namestring, utf8name);
+    retval->SetName(namestring);
   }
 
   *result = v8impl::JsValueFromV8LocalValue(retval);

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -110,6 +110,7 @@ NODE_EXTERN napi_status napi_create_symbol(napi_env e,
 NODE_EXTERN napi_status napi_create_function(napi_env e,
                                              napi_callback cb,
                                              void* data,
+                                             napi_propertyname name,
                                              napi_value* result);
 NODE_EXTERN napi_status napi_create_error(napi_env e,
                                           napi_value msg,
@@ -239,9 +240,6 @@ NODE_EXTERN napi_status napi_strict_equals(napi_env e,
                                            bool* result);
 
 // Methods to work with Functions
-NODE_EXTERN napi_status napi_set_function_name(napi_env e,
-                                               napi_value func,
-                                               napi_propertyname napi_value);
 NODE_EXTERN napi_status napi_call_function(napi_env e,
                                            napi_value recv,
                                            napi_value func,

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -108,9 +108,9 @@ NODE_EXTERN napi_status napi_create_symbol(napi_env e,
                                            const char* s,
                                            napi_value* result);
 NODE_EXTERN napi_status napi_create_function(napi_env e,
+                                             const char* utf8name,
                                              napi_callback cb,
                                              void* data,
-                                             const char* utf8name,
                                              napi_value* result);
 NODE_EXTERN napi_status napi_create_error(napi_env e,
                                           napi_value msg,

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -110,7 +110,7 @@ NODE_EXTERN napi_status napi_create_symbol(napi_env e,
 NODE_EXTERN napi_status napi_create_function(napi_env e,
                                              napi_callback cb,
                                              void* data,
-                                             napi_propertyname name,
+                                             const char* utf8name,
                                              napi_value* result);
 NODE_EXTERN napi_status napi_create_error(napi_env e,
                                           napi_value msg,

--- a/test/addons-abi/5_function_factory/binding.cc
+++ b/test/addons-abi/5_function_factory/binding.cc
@@ -15,7 +15,7 @@ void CreateFunction(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value fn;
-  status = napi_create_function(env, MyFunction, nullptr, &fn);
+  status = napi_create_function(env, MyFunction, nullptr, nullptr, &fn);
   if (status != napi_ok) return;
 
   napi_propertyname name;

--- a/test/addons-abi/5_function_factory/binding.cc
+++ b/test/addons-abi/5_function_factory/binding.cc
@@ -15,7 +15,7 @@ void CreateFunction(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value fn;
-  status = napi_create_function(env, MyFunction, nullptr, "theFunction", &fn);
+  status = napi_create_function(env, "theFunction", MyFunction, nullptr, &fn);
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, fn);

--- a/test/addons-abi/5_function_factory/binding.cc
+++ b/test/addons-abi/5_function_factory/binding.cc
@@ -14,16 +14,12 @@ void MyFunction(napi_env env, napi_callback_info info) {
 void CreateFunction(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value fn;
-  status = napi_create_function(env, MyFunction, nullptr, nullptr, &fn);
-  if (status != napi_ok) return;
-
   napi_propertyname name;
   status = napi_property_name(env, "theFunction", &name);
   if (status != napi_ok) return;
 
-  // omit this to make it anonymous
-  status = napi_set_function_name(env, fn, name);
+  napi_value fn;
+  status = napi_create_function(env, MyFunction, nullptr, name, &fn);
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, fn);
@@ -32,7 +28,7 @@ void CreateFunction(napi_env env, napi_callback_info info) {
 
 void Init(napi_env env, napi_value exports, napi_value module) {
   napi_status status;
-  napi_property_descriptor desc = { "exports", CreateFunction };
+  napi_property_descriptor desc = { "exports", CreateFunction, nullptr, nullptr, nullptr, napi_default, nullptr };
   status = napi_define_properties(env, module, 1, &desc);
   if (status != napi_ok) return;
 }

--- a/test/addons-abi/5_function_factory/binding.cc
+++ b/test/addons-abi/5_function_factory/binding.cc
@@ -1,4 +1,4 @@
-#include <node_jsvmapi.h>
+﻿#include <node_jsvmapi.h>
 
 void MyFunction(napi_env env, napi_callback_info info) {
   napi_status status;
@@ -14,12 +14,8 @@ void MyFunction(napi_env env, napi_callback_info info) {
 void CreateFunction(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_propertyname name;
-  status = napi_property_name(env, "theFunction", &name);
-  if (status != napi_ok) return;
-
   napi_value fn;
-  status = napi_create_function(env, MyFunction, nullptr, name, &fn);
+  status = napi_create_function(env, MyFunction, nullptr, "theFunction", &fn);
   if (status != napi_ok) return;
 
   status = napi_set_return_value(env, info, fn);

--- a/test/addons-abi/test_function/test_function.cc
+++ b/test/addons-abi/test_function/test_function.cc
@@ -1,4 +1,4 @@
-#include <node_jsvmapi.h>
+﻿#include <node_jsvmapi.h>
 
 void Test(napi_env env, napi_callback_info info) {
   napi_status status;
@@ -49,7 +49,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   if (status != napi_ok) return;
 
   napi_value fn;
-  status =  napi_create_function(env, Test, nullptr, &fn);
+  status =  napi_create_function(env, Test, nullptr, nullptr, &fn);
   if (status != napi_ok) return;
 
   status = napi_set_property(env, exports, name, fn);


### PR DESCRIPTION
Add an optional name parameter to napi_create_function.

Also change V8LocalValueFromJsPropertyName to V8LocalStringFromJsPropertyName instead since these are always string values.