### PR TITLE
napi: remove build flag but keep runtime flag

### DIFF
--- a/configure
+++ b/configure
@@ -474,18 +474,6 @@ parser.add_option('--without-bundled-v8',
     help='do not use V8 includes from the bundled deps folder. ' +
          '(This mode is not officially supported for regular applications)')
 
-parser.add_option('--with-napi',
-    action='store_true',
-    dest='enable_napi',
-    default=True,
-    help='Build with ABI-stable API for addons. (Default)')
-
-parser.add_option('--without-napi',
-    action='store_false',
-    dest='enable_napi',
-    default=True,
-    help='Build without ABI-stable API for addons.')
-
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -779,7 +767,6 @@ def configure_mips(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
-  o['variables']['enable_napi'] = b(options.enable_napi)
   o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
@@ -1349,7 +1336,6 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
-  'NAPI': str(options.enable_napi)
 }
 
 if options.prefix:

--- a/node.gyp
+++ b/node.gyp
@@ -156,6 +156,10 @@
         'src/handle_wrap.cc',
         'src/js_stream.cc',
         'src/node.cc',
+        'src/node_asyncapi.cc',
+        'src/node_asyncapi.h',
+        'src/node_asyncapi_internal.h',
+        'src/node_asyncapi_types.h',
         'src/node_buffer.cc',
         'src/node_config.cc',
         'src/node_constants.cc',
@@ -164,6 +168,10 @@
         'src/node_file.cc',
         'src/node_http_parser.cc',
         'src/node_javascript.cc',
+        'src/node_jsvmapi.cc',
+        'src/node_jsvmapi.h',
+        'src/node_jsvmapi_internal.h',
+        'src/node_jsvmapi_types.h',
         'src/node_main.cc',
         'src/node_os.cc',
         'src/node_revert.cc',
@@ -256,21 +264,6 @@
 
 
       'conditions': [
-        [ 'enable_napi=="true"', {
-          'sources': [
-            'src/node_asyncapi.cc',
-            'src/node_jsvmapi.cc',
-            'src/node_asyncapi.h',
-            'src/node_asyncapi_internal.h',
-            'src/node_asyncapi_types.h',
-            'src/node_jsvmapi.h',
-            'src/node_jsvmapi_internal.h',
-            'src/node_jsvmapi_types.h'
-          ],
-          'defines': [
-            'ENABLE_NAPI'
-          ]
-        }],
         [ 'node_shared=="false"', {
           'msvs_settings': {
             'VCManifestTool': {

--- a/src/node.cc
+++ b/src/node.cc
@@ -29,10 +29,6 @@
 #include "node_lttng.h"
 #endif
 
-#if defined ENABLE_NAPI
-#include "node_jsvmapi_internal.h"
-#endif
-
 #include "ares.h"
 #include "async-wrap.h"
 #include "async-wrap-inl.h"
@@ -164,7 +160,7 @@ static const char* icu_data_dir = nullptr;
 #endif
 
 // By default we accept N-API addons
-bool no_napi_modules = false;
+bool load_napi_modules = true;
 
 // used by C++ modules as well
 bool no_deprecation = false;
@@ -2427,7 +2423,6 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
     env->ThrowError("Module did not self-register.");
     return;
   }
-
   if (mp->nm_version != NODE_MODULE_VERSION) {
     char errmsg[1024];
     if (mp->nm_version == -1) {
@@ -3519,6 +3514,7 @@ static void PrintHelp() {
          "  --trace-deprecation        show stack traces on deprecations\n"
          "  --throw-deprecation        throw an exception on deprecations\n"
          "  --no-warnings              silence all process warnings\n"
+         "  --napi-modules[=yes|no]    load N-API modules (default no)\n"
          "  --trace-warnings           show stack traces on process warnings\n"
          "  --redirect-warnings=path\n"
          "                             write warnings to path instead of\n"
@@ -3686,8 +3682,12 @@ static void ParseArgs(int* argc,
       force_repl = true;
     } else if (strcmp(arg, "--no-deprecation") == 0) {
       no_deprecation = true;
-    } else if (strcmp(arg, "--no-napi-modules") == 0) {
-      no_napi_modules = true;
+    } else if (strcmp(arg, "--napi-modules") == 0) {
+      load_napi_modules = true;
+    } else if (strcmp(arg, "--napi-modules=yes") == 0) {
+      load_napi_modules = true;
+    } else if (strcmp(arg, "--napi-modules=no") == 0) {
+      load_napi_modules = false;
     } else if (strcmp(arg, "--no-warnings") == 0) {
       no_process_warnings = true;
     } else if (strcmp(arg, "--trace-warnings") == 0) {

--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -505,14 +505,14 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
 
 namespace node {
   // Indicates whether NAPI was enabled/disabled via the node command-line.
-  extern bool no_napi_modules;
+  extern bool load_napi_modules;
 }
 
 // Registers a NAPI module.
 void napi_module_register(napi_module* mod) {
   // NAPI modules always work with the current node version.
   int moduleVersion = NODE_MODULE_VERSION;
-  if (node::no_napi_modules) {
+  if (!node::load_napi_modules) {
     // NAPI is disabled, so set the module version to -1 to cause the module to be unloaded.
     moduleVersion = -1;
   }

--- a/test/addons-abi/testcfg.py
+++ b/test/addons-abi/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.AddonTestConfiguration(context, root, 'addon-abi')
+  return testpy.AddonTestConfiguration(context, root, 'addons-abi', ['--napi-modules=yes'])

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -150,5 +150,5 @@ class AddonTestConfiguration(SimpleTestConfiguration):
       if self.Contains(path, test):
         file_path = join(self.root, reduce(join, test[1:], "") + ".js")
         result.append(
-            SimpleTestCase(test, file_path, arch, mode, self.context, self))
+            SimpleTestCase(test, file_path, arch, mode, self.context, self, self.additional_flags))
     return result

--- a/tools/install.py
+++ b/tools/install.py
@@ -106,7 +106,7 @@ def subdir_files(path, dest, action):
   for subdir, files in ret.items():
     action(files, subdir + '/')
 
-def files(action, conf):
+def files(action):
   is_windows = sys.platform == 'win32'
   output_file = 'node'
   output_prefix = 'out/Release/'
@@ -141,25 +141,22 @@ def files(action, conf):
 
   if 'true' == variables.get('node_install_npm'): npm_files(action)
 
-  headers(action, conf)
+  headers(action)
 
-def headers(action, conf):
+def headers(action):
   action([
     'common.gypi',
     'config.gypi',
     'src/node.h',
+    'src/node_asyncapi.h',
+    'src/node_asyncapi_types.h',
+    'src/node_jsvmapi.h',
+    'src/node_jsvmapi_types.h',
     'src/node_macros.h',
     'src/node_buffer.h',
     'src/node_object_wrap.h',
-    'src/node_version.h'
+    'src/node_version.h',
   ], 'include/node/')
-  if conf['variables']['enable_napi'] == 'true':
-    action([
-      'src/node_asyncapi.h',
-      'src/node_asyncapi_types.h',
-      'src/node_jsvmapi.h',
-      'src/node_jsvmapi_types.h'
-    ], 'include/node/')
 
   # Add the expfile that is created on AIX
   if sys.platform.startswith('aix'):
@@ -208,11 +205,11 @@ def run(args):
   cmd = args[1] if len(args) > 1 else 'install'
 
   if os.environ.get('HEADERS_ONLY'):
-    if cmd == 'install': return headers(install, conf)
-    if cmd == 'uninstall': return headers(uninstall, conf)
+    if cmd == 'install': return headers(install)
+    if cmd == 'uninstall': return headers(uninstall)
   else:
-    if cmd == 'install': return files(install, conf)
-    if cmd == 'uninstall': return files(uninstall, conf)
+    if cmd == 'install': return files(install)
+    if cmd == 'uninstall': return files(uninstall)
 
   raise RuntimeError('Bad command: %s\n' % cmd)
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -36,7 +36,6 @@ set i18n_arg=
 set download_arg=
 set build_release=
 set enable_vtune_arg=
-set without_napi_arg=
 set configure_flags=
 set build_addons=
 set dll=
@@ -85,7 +84,6 @@ if /i "%1"=="without-intl"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
-if /i "%1"=="without-napi"  set without_napi=1&goto arg-ok
 if /i "%1"=="dll"           set dll=1&goto arg-ok
 
 echo Error: invalid command line option `%1`.
@@ -117,7 +115,6 @@ if defined noperfctr set configure_flags=%configure_flags% --without-perfctr& se
 if defined release_urlbase set configure_flags=%configure_flags% --release-urlbase=%release_urlbase%
 if defined download_arg set configure_flags=%configure_flags% %download_arg%
 if defined enable_vtune_arg set configure_flags=%configure_flags% --enable-vtune-profiling
-if defined without_napi_arg set configure_flags=%configure_flags% --without-napi
 if defined dll set configure_flags=%configure_flags% --shared
 
 if "%i18n_arg%"=="full-icu" set configure_flags=%configure_flags% --with-intl=full-icu
@@ -389,7 +386,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vc2015] [download-all] [enable-vtune] [enable-napi]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vc2015] [download-all] [enable-vtune]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build
@@ -397,7 +394,6 @@ echo   vcbuild.bat release msi    : builds release build and MSI installer packa
 echo   vcbuild.bat test           : builds debug build and runs tests
 echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
 echo   vcbuild.bat enable-vtune   : builds nodejs with Intel VTune profiling support to profile JavaScript
-echo   vcbuild.bat enable-napi    : builds nodejs with ABI-stable C API support for addons
 goto exit
 
 :exit


### PR DESCRIPTION
Fixes https://github.com/nodejs/abi-stable-node/issues/137

I haven't yet tested on Windows whether it refuses to load a N-API module with `--napi-modules=no`.

The patch is organized as an intentional bug. It's set up to not allow N-API modules by default, but the global`load_napi_modules` in node.cc is initially set to `true`. When we submit the PR, we need to set that `false` first. Then, it will be necessary to specify either `--napi-modules` or `--napi-modules=yes` on the node command line.