### PR TITLE
napi: Buffer data argument should be void* instead of char*

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -2020,7 +2020,7 @@ napi_status napi_get_and_clear_last_exception(napi_env e, napi_value* result) {
   return napi_ok;
 }
 
-napi_status napi_create_buffer(napi_env e, size_t size, char** data,
+napi_status napi_create_buffer(napi_env e, size_t size, void** data,
                                napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(data);
@@ -2038,13 +2038,14 @@ napi_status napi_create_buffer(napi_env e, size_t size, char** data,
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_create_external_buffer(napi_env e, size_t size, char* data,
+napi_status napi_create_external_buffer(napi_env e, size_t size, void* data,
                                         napi_finalize finalize_cb,
                                         napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
-  auto maybe = node::Buffer::New(v8impl::V8IsolateFromJsEnv(e), data, size,
+  auto maybe = node::Buffer::New(v8impl::V8IsolateFromJsEnv(e), 
+    static_cast<char*>(data), size,
     (node::Buffer::FreeCallback)finalize_cb, nullptr);
 
   CHECK_MAYBE_EMPTY(maybe, napi_generic_failure);
@@ -2053,12 +2054,13 @@ napi_status napi_create_external_buffer(napi_env e, size_t size, char* data,
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_create_buffer_copy(napi_env e, const char* data,
+napi_status napi_create_buffer_copy(napi_env e, const void* data,
                                     size_t size, napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
-  auto maybe = node::Buffer::Copy(v8impl::V8IsolateFromJsEnv(e), data, size);
+  auto maybe = node::Buffer::Copy(v8impl::V8IsolateFromJsEnv(e), 
+    static_cast<const char*>(data), size);
 
   CHECK_MAYBE_EMPTY(maybe, napi_generic_failure);
 
@@ -2074,7 +2076,7 @@ napi_status napi_is_buffer(napi_env e, napi_value v, bool* result) {
   return GET_RETURN_STATUS();
 }
 
-napi_status napi_get_buffer_info(napi_env e, napi_value v, char** data,
+napi_status napi_get_buffer_info(napi_env e, napi_value v, void** data,
                                  size_t* length) {
   NAPI_PREAMBLE(e);
 

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -390,21 +390,21 @@ NODE_EXTERN napi_status napi_get_and_clear_last_exception(napi_env e,
 // Methods to provide node::Buffer functionality with napi types
 NODE_EXTERN napi_status napi_create_buffer(napi_env e,
                                            size_t size,
-                                           char** data,
+                                           void** data,
                                            napi_value* result);
 NODE_EXTERN napi_status napi_create_external_buffer(napi_env e,
                                                     size_t size,
-                                                    char* data,
+                                                    void* data,
                                                     napi_finalize finalize_cb,
                                                     napi_value* result);
 NODE_EXTERN napi_status napi_create_buffer_copy(napi_env e,
-                                                const char* data,
+                                                const void* data,
                                                 size_t size,
                                                 napi_value* result);
 NODE_EXTERN napi_status napi_is_buffer(napi_env e, napi_value v, bool* result);
 NODE_EXTERN napi_status napi_get_buffer_info(napi_env e,
                                              napi_value v,
-                                             char** data,
+                                             void** data,
                                              size_t* length);
 
 // Methods to work with array buffers and typed arrays

--- a/test/addons-abi/test_buffer/test_buffer.cc
+++ b/test/addons-abi/test_buffer/test_buffer.cc
@@ -1,4 +1,4 @@
-#include <string.h>
+﻿#include <string.h>
 #include <string>
 #include <node_api_helpers.h>
 
@@ -32,7 +32,7 @@ static void noopDeleter(void *data) {
 NAPI_METHOD(newBuffer) {
   napi_value theBuffer;
   char *theCopy;
-  NAPI_CALL(env, napi_create_buffer(env, sizeof(theText), &theCopy,
+  NAPI_CALL(env, napi_create_buffer(env, sizeof(theText), (void**)&theCopy,
     &theBuffer));
   JS_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   strcpy(theCopy, theText);
@@ -88,7 +88,7 @@ NAPI_METHOD(bufferInfo) {
   NAPI_CALL(env, napi_get_cb_args(env, info, &theBuffer, 1));
   char *bufferData;
   size_t bufferLength;
-  NAPI_CALL(env, napi_get_buffer_info(env, theBuffer, &bufferData,
+  NAPI_CALL(env, napi_get_buffer_info(env, theBuffer, (void**)&bufferData,
     &bufferLength));
   NAPI_CALL(env, napi_create_boolean(env,
     !strcmp(bufferData, theText) && bufferLength == sizeof(theText),


### PR DESCRIPTION
Seems the fact that these API take ```char*``` for the data parameter was more of a historical oversight in the design of ```node::Buffer``` than anything else. We should take the opportunity to clean up this rough edge with the new API contract.

Fixes https://github.com/nodejs/abi-stable-node/issues/135