### PR TITLE
Argv array pointers should be const

### DIFF
--- a/src/node_jsvmapi.cc
+++ b/src/node_jsvmapi.cc
@@ -1372,7 +1372,7 @@ napi_status napi_call_function(napi_env e,
                                napi_value recv,
                                napi_value func,
                                int argc,
-                               napi_value* argv,
+                               const napi_value* argv,
                                napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -1881,7 +1881,7 @@ napi_status napi_close_handle_scope(napi_env e, napi_handle_scope scope) {
 napi_status napi_new_instance(napi_env e,
                               napi_value cons,
                               int argc,
-                              napi_value* argv,
+                              const napi_value* argv,
                               napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -1963,7 +1963,7 @@ napi_status napi_make_callback(napi_env e,
                                napi_value recv,
                                napi_value func,
                                int argc,
-                               napi_value* argv,
+                               const napi_value* argv,
                                napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);

--- a/src/node_jsvmapi.h
+++ b/src/node_jsvmapi.h
@@ -243,12 +243,12 @@ NODE_EXTERN napi_status napi_call_function(napi_env e,
                                            napi_value recv,
                                            napi_value func,
                                            int argc,
-                                           napi_value* argv,
+                                           const napi_value* argv,
                                            napi_value* result);
 NODE_EXTERN napi_status napi_new_instance(napi_env e,
                                           napi_value cons,
                                           int argc,
-                                          napi_value* argv,
+                                          const napi_value* argv,
                                           napi_value* result);
 NODE_EXTERN napi_status napi_instanceof(napi_env e, napi_value obj,
                                         napi_value cons, bool* result);
@@ -258,7 +258,7 @@ NODE_EXTERN napi_status napi_make_callback(napi_env e,
                                            napi_value recv,
                                            napi_value func,
                                            int argc,
-                                           napi_value* argv,
+                                           const napi_value* argv,
                                            napi_value* result);
 
 // Methods to work with napi_callbacks


### PR DESCRIPTION
I noticed this bug when I was working on the C++ wrappers and had to use `const_cast` in a few places where it shouldn't have been necessary.