### PR TITLE
napi: Fix test build break in test_function.cc

### DIFF
--- a/test/addons-abi/test_error/test.js
+++ b/test/addons-abi/test_error/test.js
@@ -32,7 +32,7 @@ assert.strictEqual(test_error.checkError(theRangeError), true,
 
 // Test that native reference error object is correctly classed
 assert.strictEqual(test_error.checkError(theReferenceError), true,
-                   'Reference error object correctly classed by' + 
+                   'Reference error object correctly classed by' +
                    ' napi_is_error');
 
 // Test that native URI error object is correctly classed

--- a/test/addons-abi/test_error/test.js
+++ b/test/addons-abi/test_error/test.js
@@ -17,30 +17,36 @@ const myError = new MyError('Some MyError');
 // Test that native error object is correctly classed
 assert.strictEqual(test_error.checkError(theError), true,
                    'Error object correctly classed by napi_is_error');
-                   
+
 // Test that native type error object is correctly classed
 assert.strictEqual(test_error.checkError(theTypeError), true,
                    'Type error object correctly classed by napi_is_error');
-                   
+
 // Test that native syntax error object is correctly classed
 assert.strictEqual(test_error.checkError(theSyntaxError), true,
                    'Syntax error object correctly classed by napi_is_error');
-                   
+
 // Test that native range error object is correctly classed
 assert.strictEqual(test_error.checkError(theRangeError), true,
                    'Range error object correctly classed by napi_is_error');
-                   
+
+// Test that native reference error object is correctly classed
+assert.strictEqual(test_error.checkError(theReferenceError), true,
+                   'Reference error object correctly classed by' + 
+                   ' napi_is_error');
+
 // Test that native URI error object is correctly classed
 assert.strictEqual(test_error.checkError(theURIError), true,
                    'URI error object correctly classed by napi_is_error');
-                   
+
 // Test that native eval error object is correctly classed
 assert.strictEqual(test_error.checkError(theEvalError), true,
                    'Eval error object correctly classed by napi_is_error');
-                   
+
 // Test that class derived from native error is correctly classed
 assert.strictEqual(test_error.checkError(myError), true,
-                   'Class derived from native error correctly classed by napi_is_error');
+                   'Class derived from native error correctly classed by' +
+                   ' napi_is_error');
 
 // Test that non-error object is correctly classed
 assert.strictEqual(test_error.checkError({}), false,

--- a/test/addons-abi/test_function/test_function.cc
+++ b/test/addons-abi/test_function/test_function.cc
@@ -49,7 +49,7 @@ void Init(napi_env env, napi_value exports, napi_value module) {
   if (status != napi_ok) return;
 
   napi_value fn;
-  status =  napi_create_function(env, Test, nullptr, nullptr, &fn);
+  status =  napi_create_function(env, nullptr, Test, nullptr, &fn);
   if (status != napi_ok) return;
 
   status = napi_set_property(env, exports, name, fn);


### PR DESCRIPTION
https://github.com/nodejs/abi-stable-node/pull/142 broke test_function.cc in addons-abi because of a last minute change to re-order the parameters to ```napi_create_function``` which wasn't propagated into all the tests.