### PR TITLE
Remove regfunc cast from NAPI_MODULE

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -54,7 +54,7 @@ struct napi_module {
       NAPI_MODULE_VERSION,                                            \
       flags,                                                          \
       __FILE__,                                                       \
-      (node::napi_addon_register_func)regfunc,                        \
+      regfunc,                                                        \
       #modname,                                                       \
       priv,                                                           \
       {0},                                                            \

--- a/test/addons-napi/1_hello_world/binding.cc
+++ b/test/addons-napi/1_hello_world/binding.cc
@@ -12,7 +12,7 @@ void Method(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
   napi_property_descriptor desc = DECLARE_NAPI_METHOD("hello", Method);
   status = napi_define_properties(env, exports, 1, &desc);

--- a/test/addons-napi/2_function_arguments/binding.cc
+++ b/test/addons-napi/2_function_arguments/binding.cc
@@ -48,7 +48,7 @@ void Add(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
   napi_property_descriptor addDescriptor = DECLARE_NAPI_METHOD("add", Add);
   status = napi_define_properties(env, exports, 1, &addDescriptor);

--- a/test/addons-napi/3_callbacks/binding.cc
+++ b/test/addons-napi/3_callbacks/binding.cc
@@ -38,7 +38,7 @@ void RunCallbackWithRecv(napi_env env, const napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
   napi_property_descriptor desc[2] = {
       DECLARE_NAPI_METHOD("RunCallback", RunCallback),

--- a/test/addons-napi/4_object_factory/binding.cc
+++ b/test/addons-napi/4_object_factory/binding.cc
@@ -21,7 +21,7 @@ void CreateObject(napi_env env, const napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
   napi_property_descriptor desc = DECLARE_NAPI_METHOD("exports", CreateObject);
   status = napi_define_properties(env, module, 1, &desc);

--- a/test/addons-napi/5_function_factory/binding.cc
+++ b/test/addons-napi/5_function_factory/binding.cc
@@ -25,7 +25,7 @@ void CreateFunction(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
   napi_property_descriptor desc =
       DECLARE_NAPI_METHOD("exports", CreateFunction);

--- a/test/addons-napi/6_object_wrap/binding.cc
+++ b/test/addons-napi/6_object_wrap/binding.cc
@@ -1,6 +1,6 @@
 #include "myobject.h"
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   MyObject::Init(env, exports);
 }
 

--- a/test/addons-napi/7_factory_wrap/binding.cc
+++ b/test/addons-napi/7_factory_wrap/binding.cc
@@ -18,7 +18,7 @@ void CreateObject(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   status = MyObject::Init(env);

--- a/test/addons-napi/8_passing_wrapped/binding.cc
+++ b/test/addons-napi/8_passing_wrapped/binding.cc
@@ -40,7 +40,7 @@ void Add(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   MyObject::Init(env);

--- a/test/addons-napi/test_array/test_array.cc
+++ b/test/addons-napi/test_array/test_array.cc
@@ -121,7 +121,7 @@ void New(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_buffer/test_buffer.cc
+++ b/test/addons-napi/test_buffer/test_buffer.cc
@@ -131,7 +131,7 @@ void staticBuffer(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_value theValue;
 
   NAPI_CALL(env, napi_create_string_utf8(env,

--- a/test/addons-napi/test_constructor/test_constructor.cc
+++ b/test/addons-napi/test_constructor/test_constructor.cc
@@ -74,7 +74,7 @@ void New(napi_env env, napi_callback_info info) {
   if (status != napi_ok) return;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_value number;

--- a/test/addons-napi/test_error/test_error.cc
+++ b/test/addons-napi/test_error/test_error.cc
@@ -26,7 +26,7 @@ void checkError(napi_env e, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_exception/test_exception.cc
+++ b/test/addons-napi/test_exception/test_exception.cc
@@ -58,7 +58,7 @@ void wasPending(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_function/test_function.cc
+++ b/test/addons-napi/test_function/test_function.cc
@@ -41,7 +41,7 @@ void Test(napi_env env, napi_callback_info info) {
   if (status != napi_ok) return;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_value fn;

--- a/test/addons-napi/test_instanceof/test_instanceof.cc
+++ b/test/addons-napi/test_instanceof/test_instanceof.cc
@@ -24,7 +24,7 @@ void doInstanceOf(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_number/test_number.cc
+++ b/test/addons-napi/test_number/test_number.cc
@@ -40,7 +40,7 @@ void Test(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_object/test_object.cc
+++ b/test/addons-napi/test_object/test_object.cc
@@ -227,7 +227,7 @@ void Inflate(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_properties/test_properties.cc
+++ b/test/addons-napi/test_properties/test_properties.cc
@@ -62,7 +62,7 @@ void Echo(napi_env env, napi_callback_info info) {
   if (status != napi_ok) return;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_value number;

--- a/test/addons-napi/test_string/test_string.cc
+++ b/test/addons-napi/test_string/test_string.cc
@@ -117,7 +117,7 @@ void Utf8Length(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor properties[] = {

--- a/test/addons-napi/test_symbol/test_symbol.cc
+++ b/test/addons-napi/test_symbol/test_symbol.cc
@@ -85,7 +85,7 @@ void New(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor properties[] = {

--- a/test/addons-napi/test_typedarray/test_typedarray.cc
+++ b/test/addons-napi/test_typedarray/test_typedarray.cc
@@ -129,7 +129,7 @@ void External(napi_env env, napi_callback_info info) {
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, func, 0, 0, 0, napi_default, 0 }
 
-void Init(napi_env env, napi_value exports, napi_value module) {
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;
 
   napi_property_descriptor descriptors[] = {


### PR DESCRIPTION
NAPI has two variants of module registration macros: the one here for the C API (recently renamed to NAPI_MODULE) and [one for the C++ API](https://github.com/nodejs/abi-stable-node-wrapper/blob/master/napi-inl.h#L17) (to be renamed to... NODE_API_MODULE?). Because of this cast, if you use the wrong macro then the code can still compile, but at runtime you'll get a crash during registration, and the cause is not at all obvious even when debugging.

The cast originally was copied from the [similar macro in node.h](https://github.com/nodejs/abi-stable-node/blob/api-prototype-8.x/src/node.h#L430), but I'm pretty sure it's only there for historical reasons. (They added a parameter while remaining compatible with older code.) We don't need it for NAPI, and it is likely to cause confusion if we keep it.

Without the cast, you get a build error if you use the wrong macro, which is good.