### PR TITLE
Add warning about experimental status

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3682,10 +3682,9 @@ static void ParseArgs(int* argc,
       force_repl = true;
     } else if (strcmp(arg, "--no-deprecation") == 0) {
       no_deprecation = true;
-    } else if (strcmp(arg, "--napi-modules") == 0 ||
-               strcmp(arg, "--napi-modules=yes") == 0) {
-      fprintf(stderr, "Warning: N-API is an experimental feature "
-        "and could change at any time.\n");
+    } else if (strcmp(arg, "--napi-modules") == 0) {
+      load_napi_modules = true;
+    } else if (strcmp(arg, "--napi-modules=yes") == 0) {
       load_napi_modules = true;
     } else if (strcmp(arg, "--napi-modules=no") == 0) {
       load_napi_modules = false;
@@ -4438,6 +4437,11 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   // Enable debugger
   if (debug_enabled)
     EnableDebug(&env);
+
+  if (load_napi_modules) {
+    ProcessEmitWarning(&env, "N-API is an experimental feature "
+        "and could change at any time.");
+  }
 
   {
     SealHandleScope seal(isolate);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3682,9 +3682,10 @@ static void ParseArgs(int* argc,
       force_repl = true;
     } else if (strcmp(arg, "--no-deprecation") == 0) {
       no_deprecation = true;
-    } else if (strcmp(arg, "--napi-modules") == 0) {
-      load_napi_modules = true;
-    } else if (strcmp(arg, "--napi-modules=yes") == 0) {
+    } else if (strcmp(arg, "--napi-modules") == 0 ||
+               strcmp(arg, "--napi-modules=yes") == 0) {
+      fprintf(stderr, "Warning: N-API is an experimental feature "
+        "and could change at any time.\n");
       load_napi_modules = true;
     } else if (strcmp(arg, "--napi-modules=no") == 0) {
       load_napi_modules = false;


### PR DESCRIPTION
Fixes https://github.com/nodejs/abi-stable-node/issues/162

Note the warning does not display when `load_napi_modules` *defaults* to on, which is currently the case. We planned to switch that default to off anyway when making the PR.