### PR TITLE
Rename addons_abi to addons_napi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,12 +263,12 @@ test/addons/.buildstamp: config.gypi \
 # TODO(bnoordhuis) Force rebuild after gyp update.
 build-addons: $(NODE_EXE) test/addons/.buildstamp
 
-ADDONS_ABI_BINDING_GYPS := \
+ADDONS_NAPI_BINDING_GYPS := \
 	$(filter-out test/addons-napi/??_*/binding.gyp, \
 		$(wildcard test/addons-napi/*/binding.gyp))
 
 # Implicitly depends on $(NODE_EXE), see the build-addons-napi rule for rationale.
-test/addons-napi/.buildstamp: $(ADDONS_ABI_BINDING_GYPS) \
+test/addons-napi/.buildstamp: $(ADDONS_NAPI_BINDING_GYPS) \
 	deps/uv/include/*.h deps/v8/include/*.h \
 	src/node.h src/node_buffer.h src/node_object_wrap.h
 	# Cannot use $(wildcard test/addons-napi/*/) here, it's evaluated before

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -40,7 +40,7 @@ set enable_vtune_arg=
 set configure_flags=
 set build_addons=
 set dll=
-set build_addons_abi=
+set build_addons_napi=
 set test_node_inspect=
 
 :next-arg
@@ -60,10 +60,10 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
-if /i "%1"=="test"          set test_args=%test_args% addons addons-napi doctool known_issues message parallel sequential -J&set cpplint=1&set jslint=1&set build_addons=1&set build_addons_abi=1&goto arg-ok
-if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap addons addons-napi doctool inspector known_issues message sequential parallel&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&set build_addons=1&set build_addons_abi=1&goto arg-ok
+if /i "%1"=="test"          set test_args=%test_args% addons addons-napi doctool known_issues message parallel sequential -J&set cpplint=1&set jslint=1&set build_addons=1&set build_addons_napi=1&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap addons addons-napi doctool inspector known_issues message sequential parallel&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&set build_addons=1&set build_addons_napi=1&goto arg-ok
 if /i "%1"=="test-addons"   set test_args=%test_args% addons&set build_addons=1&goto arg-ok
-if /i "%1"=="test-addons-napi"   set test_args=%test_args% addons-napi&set build_addons_abi=1&goto arg-ok
+if /i "%1"=="test-addons-napi"   set test_args=%test_args% addons-napi&set build_addons_napi=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set build_testgc_addon=1&goto arg-ok
@@ -337,7 +337,7 @@ for /d %%F in (test\addons\*) do (
 )
 
 :build-addons-napi
-if not defined build_addons_abi goto run-tests
+if not defined build_addons_napi goto run-tests
 if not exist "%node_exe%" (
   echo Failed to find node.exe
   goto run-tests


### PR DESCRIPTION
I noticed my earlier search-and-replace missed a few instances of "addons_abi" due to having underscores instead of hyphens.