### PR TITLE
Disable N-API by default

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -181,7 +181,7 @@ std::string icu_data_dir;  // NOLINT(runtime/string)
 #endif
 
 // By default we accept N-API addons
-bool load_napi_modules = true;
+bool load_napi_modules = false;
 
 // used by C++ modules as well
 bool no_deprecation = false;


### PR DESCRIPTION
Set N-API to be off by default, unless enabled via the `--napi-modules` command-line option.

Fixes https://github.com/nodejs/abi-stable-node/issues/168

CI: https://ci.nodejs.org/job/node-test-commit-linux-abi/56/