### PR TITLE
Typedef char16_t for older MSVC

### DIFF
--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #if !defined __cplusplus || (defined(_MSC_VER) && _MSC_VER < 1900)
-    typedef unsigned short char16_t;
+    typedef uint16_t char16_t;
 #endif
 
 // JSVM API types are all opaque pointers for ABI stability

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if !defined __cplusplus || (defined(_MSC_VER) && _MSC_VER < 1900)
+    typedef unsigned short char16_t;
+#endif
+
 // JSVM API types are all opaque pointers for ABI stability
 // typedef undefined structs instead of void* for compile time type safety
 typedef struct napi_env__ *napi_env;


### PR DESCRIPTION
The `_MSC_VER < 1900` condition is copied from `uchar.h` in the Windows SDK.