### PR TITLE
Fix undefined snprintf use for older compiler

### DIFF
--- a/test/addons-napi/test_buffer/test_buffer.cc
+++ b/test/addons-napi/test_buffer/test_buffer.cc
@@ -44,7 +44,7 @@ void newBuffer(napi_env env, napi_callback_info info) {
                 reinterpret_cast<void**>(&theCopy),
                 &theBuffer));
   JS_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
-  snprintf(theCopy, kBufferSize, "%s", theText);
+  memcpy(theCopy, theText, kBufferSize);
   NAPI_CALL(env, napi_set_return_value(env, info, theBuffer));
 }
 


### PR DESCRIPTION
The `snprintf` API is not available with older versions of MSVC. Found by the CI run: https://ci.nodejs.org/job/node-test-binary-windows/7215/RUN_SUBSET=1,VS_VERSION=vs2015,label=win2008r2/console