### PR TITLE
Use size_t where appropriate

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -659,7 +659,7 @@ napi_status napi_define_class(napi_env e,
                               const char* utf8name,
                               napi_callback constructor,
                               void* data,
-                              int property_count,
+                              size_t property_count,
                               const napi_property_descriptor* properties,
                               napi_value* result) {
   NAPI_PREAMBLE(e);
@@ -683,8 +683,8 @@ napi_status napi_define_class(napi_env e,
   CHECK_NEW_FROM_UTF8(isolate, namestring, utf8name);
   tpl->SetClassName(namestring);
 
-  int staticPropertyCount = 0;
-  for (int i = 0; i < property_count; i++) {
+  size_t staticPropertyCount = 0;
+  for (size_t i = 0; i < property_count; i++) {
     const napi_property_descriptor* p = properties + i;
 
     if ((p->attributes & napi_static_property) != 0) {
@@ -738,7 +738,7 @@ napi_status napi_define_class(napi_env e,
     std::vector<napi_property_descriptor> staticDescriptors;
     staticDescriptors.reserve(staticPropertyCount);
 
-    for (int i = 0; i < property_count; i++) {
+    for (size_t i = 0; i < property_count; i++) {
       const napi_property_descriptor* p = properties + i;
       if ((p->attributes & napi_static_property) != 0) {
         staticDescriptors.push_back(*p);
@@ -991,7 +991,7 @@ napi_status napi_get_element(napi_env e,
 
 napi_status napi_define_properties(napi_env e,
                                    napi_value object,
-                                   int property_count,
+                                   size_t property_count,
                                    const napi_property_descriptor* properties) {
   NAPI_PREAMBLE(e);
 
@@ -1000,7 +1000,7 @@ napi_status napi_define_properties(napi_env e,
   v8::Local<v8::Object> obj =
       v8impl::V8LocalValueFromJsValue(object).As<v8::Object>();
 
-  for (int i = 0; i < property_count; i++) {
+  for (size_t i = 0; i < property_count; i++) {
     const napi_property_descriptor* p = &properties[i];
 
     v8::Local<v8::Name> name;
@@ -1138,7 +1138,7 @@ napi_status napi_create_array(napi_env e, napi_value* result) {
 }
 
 napi_status napi_create_array_with_length(napi_env e,
-                                          int length,
+                                          size_t length,
                                           napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -1151,7 +1151,7 @@ napi_status napi_create_array_with_length(napi_env e,
 
 napi_status napi_create_string_utf8(napi_env e,
                                     const char* s,
-                                    int length,
+                                    size_t length,
                                     napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -1166,7 +1166,7 @@ napi_status napi_create_string_utf8(napi_env e,
 
 napi_status napi_create_string_utf16(napi_env e,
                                      const char16_t* s,
-                                     int length,
+                                     size_t length,
                                      napi_value* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
@@ -1606,7 +1606,7 @@ napi_status napi_get_value_bool(napi_env e, napi_value value, bool* result) {
 // Gets the number of CHARACTERS in the string.
 napi_status napi_get_value_string_length(napi_env e,
                                          napi_value value,
-                                         int* result) {
+                                         size_t* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
@@ -1621,7 +1621,7 @@ napi_status napi_get_value_string_length(napi_env e,
 // Gets the number of BYTES in the UTF-8 encoded representation of the string.
 napi_status napi_get_value_string_utf8_length(napi_env e,
                                               napi_value value,
-                                              int* result) {
+                                              size_t* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
@@ -1640,8 +1640,8 @@ napi_status napi_get_value_string_utf8_length(napi_env e,
 napi_status napi_get_value_string_utf8(napi_env e,
                                        napi_value value,
                                        char* buf,
-                                       int bufsize,
-                                       int* result) {
+                                       size_t bufsize,
+                                       size_t* result) {
   NAPI_PREAMBLE(e);
 
   v8::Local<v8::Value> val = v8impl::V8LocalValueFromJsValue(value);
@@ -1661,7 +1661,7 @@ napi_status napi_get_value_string_utf8(napi_env e,
 // the string.
 napi_status napi_get_value_string_utf16_length(napi_env e,
                                                napi_value value,
-                                               int* result) {
+                                               size_t* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 
@@ -1683,8 +1683,8 @@ napi_status napi_get_value_string_utf16_length(napi_env e,
 napi_status napi_get_value_string_utf16(napi_env e,
                                         napi_value value,
                                         char16_t* buf,
-                                        int bufsize,
-                                        int* result) {
+                                        size_t bufsize,
+                                        size_t* result) {
   NAPI_PREAMBLE(e);
   CHECK_ARG(result);
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -279,12 +279,12 @@ NAPI_EXTERN napi_status napi_strict_equals(napi_env env,
 NAPI_EXTERN napi_status napi_call_function(napi_env env,
                                            napi_value recv,
                                            napi_value func,
-                                           int argc,
+                                           size_t argc,
                                            const napi_value* argv,
                                            napi_value* result);
 NAPI_EXTERN napi_status napi_new_instance(napi_env env,
                                           napi_value constructor,
-                                          int argc,
+                                          size_t argc,
                                           const napi_value* argv,
                                           napi_value* result);
 NAPI_EXTERN napi_status napi_instanceof(napi_env env,
@@ -296,7 +296,7 @@ NAPI_EXTERN napi_status napi_instanceof(napi_env env,
 NAPI_EXTERN napi_status napi_make_callback(napi_env env,
                                            napi_value recv,
                                            napi_value func,
-                                           int argc,
+                                           size_t argc,
                                            const napi_value* argv,
                                            napi_value* result);
 
@@ -306,7 +306,7 @@ NAPI_EXTERN napi_status napi_make_callback(napi_env env,
 NAPI_EXTERN napi_status napi_get_cb_info(
     napi_env env,               // [in] NAPI environment handle
     napi_callback_info cbinfo,  // [in] Opaque callback-info handle
-    int* argc,         // [in-out] Specifies the size of the provided argv array
+    size_t* argc,      // [in-out] Specifies the size of the provided argv array
                        // and receives the actual count of args.
     napi_value* argv,  // [out] Array of values
     napi_value* thisArg,  // [out] Receives the JS 'this' arg for the call
@@ -314,11 +314,11 @@ NAPI_EXTERN napi_status napi_get_cb_info(
 
 NAPI_EXTERN napi_status napi_get_cb_args_length(napi_env env,
                                                 napi_callback_info cbinfo,
-                                                int* result);
+                                                size_t* result);
 NAPI_EXTERN napi_status napi_get_cb_args(napi_env env,
                                          napi_callback_info cbinfo,
                                          napi_value* buffer,
-                                         int bufferlength);
+                                         size_t bufferlength);
 NAPI_EXTERN napi_status napi_get_cb_this(napi_env env,
                                          napi_callback_info cbinfo,
                                          napi_value* result);

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -113,18 +113,18 @@ NAPI_EXTERN napi_status napi_get_global(napi_env env, napi_value* result);
 NAPI_EXTERN napi_status napi_create_object(napi_env env, napi_value* result);
 NAPI_EXTERN napi_status napi_create_array(napi_env env, napi_value* result);
 NAPI_EXTERN napi_status napi_create_array_with_length(napi_env env,
-                                                      int length,
+                                                      size_t length,
                                                       napi_value* result);
 NAPI_EXTERN napi_status napi_create_number(napi_env env,
                                            double val,
                                            napi_value* result);
 NAPI_EXTERN napi_status napi_create_string_utf8(napi_env env,
                                                 const char* s,
-                                                int length,
+                                                size_t length,
                                                 napi_value* result);
 NAPI_EXTERN napi_status napi_create_string_utf16(napi_env env,
                                                  const char16_t* s,
-                                                 int length,
+                                                 size_t length,
                                                  napi_value* result);
 NAPI_EXTERN napi_status napi_create_boolean(napi_env env,
                                             bool b,
@@ -170,32 +170,32 @@ NAPI_EXTERN napi_status napi_get_value_bool(napi_env env,
 // Gets the number of CHARACTERS in the string.
 NAPI_EXTERN napi_status napi_get_value_string_length(napi_env env,
                                                      napi_value value,
-                                                     int* result);
+                                                     size_t* result);
 
 // Gets the number of BYTES in the UTF-8 encoded representation of the string.
 NAPI_EXTERN napi_status napi_get_value_string_utf8_length(napi_env env,
                                                           napi_value value,
-                                                          int* result);
+                                                          size_t* result);
 
 // Copies UTF-8 encoded bytes from a string into a buffer.
 NAPI_EXTERN napi_status napi_get_value_string_utf8(napi_env env,
                                                    napi_value value,
                                                    char* buf,
-                                                   int bufsize,
-                                                   int* result);
+                                                   size_t bufsize,
+                                                   size_t* result);
 
 // Gets the number of 2-byte code units in the UTF-16 encoded
 // representation of the string.
 NAPI_EXTERN napi_status napi_get_value_string_utf16_length(napi_env env,
                                                            napi_value value,
-                                                           int* result);
+                                                           size_t* result);
 
 // Copies UTF-16 encoded bytes from a string into a buffer.
 NAPI_EXTERN napi_status napi_get_value_string_utf16(napi_env env,
                                                     napi_value value,
                                                     char16_t* buf,
-                                                    int bufsize,
-                                                    int* result);
+                                                    size_t bufsize,
+                                                    size_t* result);
 
 // Methods to coerce values
 // These APIs may execute user script
@@ -258,7 +258,7 @@ NAPI_EXTERN napi_status napi_get_element(napi_env env,
 NAPI_EXTERN napi_status
 napi_define_properties(napi_env env,
                        napi_value object,
-                       int property_count,
+                       size_t property_count,
                        const napi_property_descriptor* properties);
 
 // Methods to work with Arrays
@@ -337,7 +337,7 @@ napi_define_class(napi_env env,
                   const char* utf8name,
                   napi_callback constructor,
                   void* data,
-                  int property_count,
+                  size_t property_count,
                   const napi_property_descriptor* properties,
                   napi_value* result);
 

--- a/test/addons-napi/2_function_arguments/binding.c
+++ b/test/addons-napi/2_function_arguments/binding.c
@@ -3,7 +3,7 @@
 void Add(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_array/test_array.c
+++ b/test/addons-napi/test_array/test_array.c
@@ -4,7 +4,7 @@
 void Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -74,7 +74,7 @@ void Test(napi_env env, napi_callback_info info) {
 void New(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -78,7 +78,7 @@ void copyBuffer(napi_env env, napi_callback_info info) {
 }
 
 void bufferHasInstance(napi_env env, napi_callback_info info) {
-  int argc;
+  size_t argc;
   NAPI_CALL(env, napi_get_cb_args_length(env, info, &argc));
   JS_ASSERT(env, argc == 1, "Wrong number of arguments");
   napi_value theBuffer;
@@ -97,7 +97,7 @@ void bufferHasInstance(napi_env env, napi_callback_info info) {
 }
 
 void bufferInfo(napi_env env, napi_callback_info info) {
-  int argc;
+  size_t argc;
   NAPI_CALL(env, napi_get_cb_args_length(env, info, &argc));
   JS_ASSERT(env, argc == 1, "Wrong number of arguments");
   napi_value theBuffer, returnValue;

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -6,7 +6,7 @@ napi_ref constructor_;
 void GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -26,7 +26,7 @@ void GetValue(napi_env env, napi_callback_info info) {
 void SetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -46,7 +46,7 @@ void SetValue(napi_env env, napi_callback_info info) {
 void Echo(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_function/test_function.c
+++ b/test/addons-napi/test_function/test_function.c
@@ -3,7 +3,7 @@
 void Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_number/test_number.c
+++ b/test/addons-napi/test_number/test_number.c
@@ -3,7 +3,7 @@
 void Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_object/test_object.c
+++ b/test/addons-napi/test_object/test_object.c
@@ -3,7 +3,7 @@
 void Get(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -48,7 +48,7 @@ void Get(napi_env env, napi_callback_info info) {
 void Set(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -96,7 +96,7 @@ void Set(napi_env env, napi_callback_info info) {
 void Has(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -169,7 +169,7 @@ void New(napi_env env, napi_callback_info info) {
 void Inflate(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -5,7 +5,7 @@ static double value_ = 1;
 void GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -25,7 +25,7 @@ void GetValue(napi_env env, napi_callback_info info) {
 void SetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -45,7 +45,7 @@ void SetValue(napi_env env, napi_callback_info info) {
 void Echo(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -65,7 +65,7 @@ void Length(napi_env env, napi_callback_info info) {
     return;
   }
 
-  int length;
+  size_t length;
   status = napi_get_value_string_length(env, args[0], &length);
   if (status != napi_ok) return;
 
@@ -102,7 +102,7 @@ void Utf8Length(napi_env env, napi_callback_info info) {
     return;
   }
 
-  int length;
+  size_t length;
   status = napi_get_value_string_utf8_length(env, args[0], &length);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -3,7 +3,7 @@
 void Copy(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -43,7 +43,7 @@ void Copy(napi_env env, napi_callback_info info) {
 void Length(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -80,7 +80,7 @@ void Length(napi_env env, napi_callback_info info) {
 void Utf8Length(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_symbol/test_symbol.c
+++ b/test/addons-napi/test_symbol/test_symbol.c
@@ -3,7 +3,7 @@
 void Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 
@@ -43,7 +43,7 @@ void Test(napi_env env, napi_callback_info info) {
 void New(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -4,7 +4,7 @@
 void Multiply(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  int argc;
+  size_t argc;
   status = napi_get_cb_args_length(env, info, &argc);
   if (status != napi_ok) return;
 


### PR DESCRIPTION
Based on feedback in the nodejs/node PR, `size_t` should be preferred over `int` generally when referring to array/buffer lengths.

I did not change uses of `int` that refer to `args` array length -- is that right or should it be `size_t` also?