### PR TITLE
all: update --napi-modules flag to not have a yes/no

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -144,6 +144,13 @@ added: v6.0.0
 
 Silence all process warnings (including deprecations).
 
+### `--napi-modules`
+<!-- YAML
+added: v8.0.0
+-->
+
+Load N-API modules.
+
 ### `--trace-warnings`
 <!-- YAML
 added: v6.0.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -149,7 +149,7 @@ Silence all process warnings (including deprecations).
 added: v8.0.0
 -->
 
-Load N-API modules.
+Load N-API modules (experimental, opt-in by adding this flag).
 
 ### `--trace-warnings`
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -120,6 +120,10 @@ Throw errors for deprecations.
 Silence all process warnings (including deprecations).
 
 .TP
+.BR \-\-napi\-modules
+Load N-API modules.
+
+.TP
 .BR \-\-trace\-warnings
 Print stack traces for process warnings (including deprecations).
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -121,7 +121,7 @@ Silence all process warnings (including deprecations).
 
 .TP
 .BR \-\-napi\-modules
-Load N-API modules.
+Load N-API modules (experimental, opt-in by adding this flag).
 
 .TP
 .BR \-\-trace\-warnings

--- a/src/node.cc
+++ b/src/node.cc
@@ -2470,9 +2470,9 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
       snprintf(errmsg,
                sizeof(errmsg),
                "The module '%s'"
-               "\nwas compiled against the Node.js API. This feature is "
-               "\nexperimental and must be enabled on the command-line by "
-               "\nadding --napi-modules.",
+               "\nwas compiled against the ABI-stable Node.js API (N-API)."
+               "\nThis feature is experimental and must be enabled on the "
+               "\ncommand-line by adding --napi-modules.",
                *filename);
     } else {
       snprintf(errmsg,

--- a/src/node.cc
+++ b/src/node.cc
@@ -2471,7 +2471,8 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
                sizeof(errmsg),
                "The module '%s'"
                "\nwas compiled against the Node.js API. This feature is "
-               "\nexperimental and must be enabled on the command-line.",
+               "\nexperimental and must be enabled on the command-line by "
+               "\nadding --napi-modules.",
                *filename);
     } else {
       snprintf(errmsg,
@@ -3548,7 +3549,7 @@ static void PrintHelp() {
          "  --trace-deprecation        show stack traces on deprecations\n"
          "  --throw-deprecation        throw an exception on deprecations\n"
          "  --no-warnings              silence all process warnings\n"
-         "  --napi-modules[=yes|no]    load N-API modules (default no)\n"
+         "  --napi-modules             load N-API modules\n"
          "  --trace-warnings           show stack traces on process warnings\n"
          "  --redirect-warnings=path\n"
          "                             write warnings to path instead of\n"
@@ -3721,10 +3722,6 @@ static void ParseArgs(int* argc,
       no_deprecation = true;
     } else if (strcmp(arg, "--napi-modules") == 0) {
       load_napi_modules = true;
-    } else if (strcmp(arg, "--napi-modules=yes") == 0) {
-      load_napi_modules = true;
-    } else if (strcmp(arg, "--napi-modules=no") == 0) {
-      load_napi_modules = false;
     } else if (strcmp(arg, "--no-warnings") == 0) {
       no_process_warnings = true;
     } else if (strcmp(arg, "--trace-warnings") == 0) {

--- a/test/addons-napi/testcfg.py
+++ b/test/addons-napi/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.AddonTestConfiguration(context, root, 'addons-napi', ['--napi-modules=yes'])
+  return testpy.AddonTestConfiguration(context, root, 'addons-napi', ['--napi-modules'])


### PR DESCRIPTION
This updates the documentation, the error message upon module load
failure, the command line option parsing of the flag, and the way
the N-API addon tests pass the flag to node.

Re https://github.com/nodejs/node/pull/11975#discussion_r107257386
Re https://github.com/nodejs/node/pull/11975#discussion_r107325207
Fixes https://github.com/nodejs/abi-stable-node/issues/184