### PR TITLE
Change napi_callback to return napi_value instead of void

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -283,7 +283,11 @@ class CallbackWrapperBase : public CallbackWrapper {
         v8::Local<v8::External>::Cast(
             _cbdata->GetInternalField(InternalFieldIndex))->Value());
     v8::Isolate* isolate = _cbinfo.GetIsolate();
-    cb(v8impl::JsEnvFromV8Isolate(isolate), cbinfo_wrapper);
+    napi_value result = cb(v8impl::JsEnvFromV8Isolate(isolate), cbinfo_wrapper);
+
+    if (result != nullptr) {
+      this->SetReturnValue(result);
+    }
 
     if (!TryCatch::LastException().IsEmpty()) {
       isolate->ThrowException(
@@ -577,6 +581,7 @@ const char* error_messages[] = {nullptr,
                                 "Invalid pointer passed as argument",
                                 "An object was expected",
                                 "A string was expected",
+                                "A string or symbol was expected",
                                 "A function was expected",
                                 "A number was expected",
                                 "A boolean was expected",
@@ -685,15 +690,24 @@ napi_status napi_define_class(napi_env env,
       continue;
     }
 
-    v8::Local<v8::String> property_name;
-    CHECK_NEW_FROM_UTF8(isolate, property_name, p->utf8name);
+    v8::Local<v8::Name> property_name;
+
+    if (p->utf8name != nullptr) {
+      CHECK_NEW_FROM_UTF8(isolate, property_name, p->utf8name);
+    } else {
+      v8::Local<v8::Value> property_value =
+        v8impl::V8LocalValueFromJsValue(p->name);
+
+      RETURN_STATUS_IF_FALSE(property_value->IsName(), napi_name_expected);
+      property_name = property_value.As<v8::Name>();
+    }
 
     v8::PropertyAttribute attributes =
         static_cast<v8::PropertyAttribute>(p->attributes);
 
     // This code is similar to that in napi_define_property(); the
     // difference is it applies to a template instead of an object.
-    if (p->method) {
+    if (p->method != nullptr) {
       v8::Local<v8::Object> cbdata =
           v8impl::CreateFunctionCallbackData(env, p->method, p->data);
 
@@ -704,10 +718,9 @@ napi_status napi_define_class(napi_env env,
                                     v8impl::FunctionCallbackWrapper::Invoke,
                                     cbdata,
                                     v8::Signature::New(isolate, tpl));
-      t->SetClassName(property_name);
 
       tpl->PrototypeTemplate()->Set(property_name, t, attributes);
-    } else if (p->getter || p->setter) {
+    } else if (p->getter != nullptr || p->setter != nullptr) {
       v8::Local<v8::Object> cbdata = v8impl::CreateAccessorCallbackData(
         env, p->getter, p->setter, p->data);
 
@@ -745,18 +758,6 @@ napi_status napi_define_class(napi_env env,
     if (status != napi_ok) return status;
   }
 
-  return GET_RETURN_STATUS();
-}
-
-napi_status napi_set_return_value(napi_env env,
-                                  napi_callback_info cbinfo,
-                                  napi_value value) {
-  NAPI_PREAMBLE(env);
-
-  v8impl::CallbackWrapper* info =
-      reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
-
-  info->SetReturnValue(value);
   return GET_RETURN_STATUS();
 }
 
@@ -995,13 +996,22 @@ napi_status napi_define_properties(napi_env env,
   for (size_t i = 0; i < property_count; i++) {
     const napi_property_descriptor* p = &properties[i];
 
-    v8::Local<v8::Name> name;
-    CHECK_NEW_FROM_UTF8(isolate, name, p->utf8name);
+    v8::Local<v8::Name> property_name;
+
+    if (p->utf8name != nullptr) {
+      CHECK_NEW_FROM_UTF8(isolate, property_name, p->utf8name);
+    } else {
+      v8::Local<v8::Value> property_value =
+        v8impl::V8LocalValueFromJsValue(p->name);
+
+      RETURN_STATUS_IF_FALSE(property_value->IsName(), napi_name_expected);
+      property_name = property_value.As<v8::Name>();
+    }
 
     v8::PropertyAttribute attributes = static_cast<v8::PropertyAttribute>(
         p->attributes & ~napi_static_property);
 
-    if (p->method) {
+    if (p->method != nullptr) {
       v8::Local<v8::Object> cbdata =
           v8impl::CreateFunctionCallbackData(env, p->method, p->data);
 
@@ -1010,15 +1020,15 @@ napi_status napi_define_properties(napi_env env,
       v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(
           isolate, v8impl::FunctionCallbackWrapper::Invoke, cbdata);
 
-      auto define_maybe =
-          obj->DefineOwnProperty(context, name, t->GetFunction(), attributes);
+      auto define_maybe = obj->DefineOwnProperty(
+        context, property_name, t->GetFunction(), attributes);
 
       // IsNothing seems like a serious failure,
       // should we return a different error code if the define failed?
       if (define_maybe.IsNothing() || !define_maybe.FromMaybe(false)) {
         return napi_set_last_error(napi_generic_failure);
       }
-    } else if (p->getter || p->setter) {
+    } else if (p->getter != nullptr || p->setter != nullptr) {
       v8::Local<v8::Object> cbdata = v8impl::CreateAccessorCallbackData(
         env,
         p->getter,
@@ -1027,7 +1037,7 @@ napi_status napi_define_properties(napi_env env,
 
       auto set_maybe = obj->SetAccessor(
           context,
-          name,
+          property_name,
           v8impl::GetterCallbackWrapper::Invoke,
           p->setter ? v8impl::SetterCallbackWrapper::Invoke : nullptr,
           cbdata,
@@ -1043,7 +1053,7 @@ napi_status napi_define_properties(napi_env env,
       v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(p->value);
 
       auto define_maybe =
-          obj->DefineOwnProperty(context, name, value, attributes);
+          obj->DefineOwnProperty(context, property_name, value, attributes);
 
       // IsNothing seems like a serious failure,
       // should we return a different error code if the define failed?
@@ -1337,32 +1347,23 @@ napi_status napi_get_cb_info(
     napi_value* argv,  // [out] Array of values
     napi_value* this_arg,  // [out] Receives the JS 'this' arg for the call
     void** data) {         // [out] Receives the data pointer for the callback.
-  CHECK_ARG(argc);
-  CHECK_ARG(argv);
-  CHECK_ARG(this_arg);
-  CHECK_ARG(data);
-
   v8impl::CallbackWrapper* info =
       reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
 
-  info->Args(argv, std::min(*argc, info->ArgsLength()));
-  *argc = info->ArgsLength();
-  *this_arg = info->This();
-  *data = info->Data();
+  if (argv != nullptr) {
+    CHECK_ARG(argc);
+    info->Args(argv, std::min(*argc, info->ArgsLength()));
+  }
+  if (argc != nullptr) {
+    *argc = info->ArgsLength();
+  }
+  if (this_arg != nullptr) {
+    *this_arg = info->This();
+  }
+  if (data != nullptr) {
+    *data = info->Data();
+  }
 
-  return napi_ok;
-}
-
-napi_status napi_get_cb_args_length(napi_env env,
-                                    napi_callback_info cbinfo,
-                                    size_t* result) {
-  // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because no V8 APIs are called.
-  CHECK_ARG(result);
-
-  v8impl::CallbackWrapper* info =
-      reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
-
-  *result = info->ArgsLength();
   return napi_ok;
 }
 
@@ -1376,48 +1377,6 @@ napi_status napi_is_construct_call(napi_env env,
       reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
 
   *result = info->IsConstructCall();
-  return napi_ok;
-}
-
-// copy encoded arguments into provided buffer or return direct pointer to
-// encoded arguments array?
-napi_status napi_get_cb_args(napi_env env,
-                             napi_callback_info cbinfo,
-                             napi_value* buf,
-                             size_t bufsize) {
-  // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because no V8 APIs are called.
-  CHECK_ARG(buf);
-
-  v8impl::CallbackWrapper* info =
-      reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
-
-  info->Args(buf, bufsize);
-  return napi_ok;
-}
-
-napi_status napi_get_cb_this(napi_env env,
-                             napi_callback_info cbinfo,
-                             napi_value* result) {
-  // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because no V8 APIs are called.
-  CHECK_ARG(result);
-
-  v8impl::CallbackWrapper* info =
-      reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
-
-  *result = info->This();
-  return napi_ok;
-}
-
-napi_status napi_get_cb_data(napi_env env,
-                             napi_callback_info cbinfo,
-                             void** result) {
-  // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because no V8 APIs are called.
-  CHECK_ARG(result);
-
-  v8impl::CallbackWrapper* info =
-      reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
-
-  *result = info->Data();
   return napi_ok;
 }
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -296,29 +296,12 @@ NAPI_EXTERN napi_status napi_get_cb_info(
     size_t* argc,      // [in-out] Specifies the size of the provided argv array
                        // and receives the actual count of args.
     napi_value* argv,  // [out] Array of values
-    napi_value* thisArg,  // [out] Receives the JS 'this' arg for the call
-    void** data);         // [out] Receives the data pointer for the callback.
+    napi_value* this_arg,  // [out] Receives the JS 'this' arg for the call
+    void** data);          // [out] Receives the data pointer for the callback.
 
-NAPI_EXTERN napi_status napi_get_cb_args_length(napi_env env,
-                                                napi_callback_info cbinfo,
-                                                size_t* result);
-NAPI_EXTERN napi_status napi_get_cb_args(napi_env env,
-                                         napi_callback_info cbinfo,
-                                         napi_value* buf,
-                                         size_t bufsize);
-NAPI_EXTERN napi_status napi_get_cb_this(napi_env env,
-                                         napi_callback_info cbinfo,
-                                         napi_value* result);
-
-NAPI_EXTERN napi_status napi_get_cb_data(napi_env env,
-                                         napi_callback_info cbinfo,
-                                         void** result);
 NAPI_EXTERN napi_status napi_is_construct_call(napi_env env,
                                                napi_callback_info cbinfo,
                                                bool* result);
-NAPI_EXTERN napi_status napi_set_return_value(napi_env env,
-                                              napi_callback_info cbinfo,
-                                              napi_value value);
 NAPI_EXTERN napi_status
 napi_define_class(napi_env env,
                   const char* utf8name,

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -17,7 +17,7 @@ typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_callback_info__ *napi_callback_info;
 
-typedef void (*napi_callback)(napi_env, napi_callback_info);
+typedef napi_value (*napi_callback)(napi_env, napi_callback_info);
 typedef void (*napi_finalize)(void* finalize_data, void* finalize_hint);
 
 typedef enum {
@@ -32,7 +32,9 @@ typedef enum {
 } napi_property_attributes;
 
 typedef struct {
+  // One of utf8name or name should be NULL.
   const char* utf8name;
+  napi_value name;
 
   napi_callback method;
   napi_callback getter;
@@ -75,6 +77,7 @@ typedef enum {
   napi_invalid_arg,
   napi_object_expected,
   napi_string_expected,
+  napi_name_expected,
   napi_function_expected,
   napi_number_expected,
   napi_boolean_expected,

--- a/test/addons-napi/1_hello_world/binding.c
+++ b/test/addons-napi/1_hello_world/binding.c
@@ -1,16 +1,15 @@
 #include <node_api.h>
 
-void Method(napi_env env, napi_callback_info info) {
+napi_value Method(napi_env env, napi_callback_info info) {
   napi_status status;
   napi_value world;
   status = napi_create_string_utf8(env, "world", -1, &world);
-  if (status != napi_ok) return;
-  status = napi_set_return_value(env, info, world);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
+  return world;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/2_function_arguments/binding.c
+++ b/test/addons-napi/2_function_arguments/binding.c
@@ -1,52 +1,54 @@
 #include <node_api.h>
 
-void Add(napi_env env, napi_callback_info info) {
+napi_value Add(napi_env env, napi_callback_info info) {
   napi_status status;
-
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype0;
   status = napi_typeof(env, args[0], &valuetype0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_valuetype valuetype1;
   status = napi_typeof(env, args[1], &valuetype1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype0 != napi_number || valuetype1 != napi_number) {
     napi_throw_type_error(env, "Wrong arguments");
-    return;
+    return NULL;
   }
 
   double value0;
   status = napi_get_value_double(env, args[0], &value0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   double value1;
   status = napi_get_value_double(env, args[1], &value1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value sum;
   status = napi_create_number(env, value0 + value1, &sum);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, sum);
-  if (status != napi_ok) return;
+  return sum;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -1,42 +1,58 @@
 #include <node_api.h>
 
-void RunCallback(napi_env env, const napi_callback_info info) {
+napi_value RunCallback(napi_env env, const napi_callback_info info) {
   napi_status status;
-
+  
+  size_t argc = 1;
   napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value cb = args[0];
 
   napi_value argv[1];
   status = napi_create_string_utf8(env, "hello world", -1, argv);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value global;
   status = napi_get_global(env, &global);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_call_function(env, global, cb, 1, argv, NULL);
-  if (status != napi_ok) return;
+  status = napi_call_function(env, global, cb, argc, argv, NULL);
+  if (status != napi_ok) return NULL;
+  return NULL;
 }
 
-void RunCallbackWithRecv(napi_env env, const napi_callback_info info) {
+napi_value RunCallbackWithRecv(napi_env env, const napi_callback_info info) {
   napi_status status;
-
+  
+  size_t argc = 2;
   napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value cb = args[0];
   napi_value recv = args[1];
 
   status = napi_call_function(env, recv, cb, 0, NULL, NULL);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
+  return NULL;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/4_object_factory/binding.c
+++ b/test/addons-napi/4_object_factory/binding.c
@@ -1,25 +1,31 @@
 #include <node_api.h>
 
-void CreateObject(napi_env env, const napi_callback_info info) {
+napi_value CreateObject(napi_env env, const napi_callback_info info) {
   napi_status status;
-
+  
+  size_t argc = 1;
   napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value obj;
   status = napi_create_object(env, &obj);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   status = napi_set_named_property(env, obj, "msg", args[0]);
-  if (status != napi_ok) return;
-
-  status = napi_set_return_value(env, info, obj);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
+  
+  return obj;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/5_function_factory/binding.c
+++ b/test/addons-napi/5_function_factory/binding.c
@@ -1,29 +1,27 @@
 #include <node_api.h>
 
-void MyFunction(napi_env env, napi_callback_info info) {
+napi_value MyFunction(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value str;
   status = napi_create_string_utf8(env, "hello world", -1, &str);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, str);
-  if (status != napi_ok) return;
+  return str;
 }
 
-void CreateFunction(napi_env env, napi_callback_info info) {
+napi_value CreateFunction(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value fn;
   status = napi_create_function(env, "theFunction", MyFunction, NULL, &fn);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, fn);
-  if (status != napi_ok) return;
+  return fn;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/6_object_wrap/myobject.h
+++ b/test/addons-napi/6_object_wrap/myobject.h
@@ -12,11 +12,11 @@ class MyObject {
   explicit MyObject(double value_ = 0);
   ~MyObject();
 
-  static void New(napi_env env, napi_callback_info info);
-  static void GetValue(napi_env env, napi_callback_info info);
-  static void SetValue(napi_env env, napi_callback_info info);
-  static void PlusOne(napi_env env, napi_callback_info info);
-  static void Multiply(napi_env env, napi_callback_info info);
+  static napi_value New(napi_env env, napi_callback_info info);
+  static napi_value GetValue(napi_env env, napi_callback_info info);
+  static napi_value SetValue(napi_env env, napi_callback_info info);
+  static napi_value PlusOne(napi_env env, napi_callback_info info);
+  static napi_value Multiply(napi_env env, napi_callback_info info);
   static napi_ref constructor;
   double value_;
   napi_env env_;

--- a/test/addons-napi/7_factory_wrap/binding.cc
+++ b/test/addons-napi/7_factory_wrap/binding.cc
@@ -1,22 +1,29 @@
 #include "myobject.h"
 
-void CreateObject(napi_env env, napi_callback_info info) {
+napi_value CreateObject(napi_env env, napi_callback_info info) {
   napi_status status;
 
+  size_t argc = 1;
   napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
+  napi_value _this;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    &_this,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value instance;
   status = MyObject::NewInstance(env, args[0], &instance);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, instance);
-  if (status != napi_ok) return;
+  return instance;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/7_factory_wrap/myobject.h
+++ b/test/addons-napi/7_factory_wrap/myobject.h
@@ -16,8 +16,8 @@ class MyObject {
   ~MyObject();
 
   static napi_ref constructor;
-  static void New(napi_env env, napi_callback_info info);
-  static void PlusOne(napi_env env, napi_callback_info info);
+  static napi_value New(napi_env env, napi_callback_info info);
+  static napi_value PlusOne(napi_env env, napi_callback_info info);
   double counter_;
   napi_env env_;
   napi_ref wrapper_;

--- a/test/addons-napi/8_passing_wrapped/binding.cc
+++ b/test/addons-napi/8_passing_wrapped/binding.cc
@@ -1,44 +1,57 @@
 #include "myobject.h"
 
-void CreateObject(napi_env env, napi_callback_info info) {
+napi_value CreateObject(napi_env env, napi_callback_info info) {
   napi_status status;
 
+  size_t argc = 1;
   napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value instance;
   status = MyObject::NewInstance(env, args[0], &instance);
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, instance);
-  if (status != napi_ok) return;
+  return instance;
 }
 
-void Add(napi_env env, napi_callback_info info) {
+napi_value Add(napi_env env, napi_callback_info info) {
   napi_status status;
 
+  size_t argc = 2;
   napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   MyObject* obj1;
   status = napi_unwrap(env, args[0], reinterpret_cast<void**>(&obj1));
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   MyObject* obj2;
   status = napi_unwrap(env, args[1], reinterpret_cast<void**>(&obj2));
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value sum;
   status = napi_create_number(env, obj1->Val() + obj2->Val(), &sum);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, sum);
-  if (status != napi_ok) return;
+  return sum;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/8_passing_wrapped/myobject.cc
+++ b/test/addons-napi/8_passing_wrapped/myobject.cc
@@ -23,41 +23,44 @@ napi_status MyObject::Init(napi_env env) {
   return napi_ok;
 }
 
-void MyObject::New(napi_env env, napi_callback_info info) {
+napi_value MyObject::New(napi_env env, napi_callback_info info) {
   napi_status status;
 
+  size_t argc = 1;
   napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
+  napi_value _this;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    &_this,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   MyObject* obj = new MyObject();
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype == napi_undefined) {
     obj->val_ = 0;
   } else {
     status = napi_get_value_double(env, args[0], &obj->val_);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
   }
-
-  napi_value jsthis;
-  status = napi_get_cb_this(env, info, &jsthis);
-  if (status != napi_ok) return;
 
   obj->env_ = env;
   status = napi_wrap(env,
-                     jsthis,
+                     _this,
                      reinterpret_cast<void*>(obj),
                      MyObject::Destructor,
                      nullptr,  // finalize_hint
                      &obj->wrapper_);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, jsthis);
-  if (status != napi_ok) return;
+  return _this;
 }
 
 napi_status MyObject::NewInstance(napi_env env,

--- a/test/addons-napi/8_passing_wrapped/myobject.h
+++ b/test/addons-napi/8_passing_wrapped/myobject.h
@@ -17,7 +17,7 @@ class MyObject {
   ~MyObject();
 
   static napi_ref constructor;
-  static void New(napi_env env, napi_callback_info info);
+  static napi_value New(napi_env env, napi_callback_info info);
   double val_;
   napi_env env_;
   napi_ref wrapper_;

--- a/test/addons-napi/test_array/test_array.c
+++ b/test/addons-napi/test_array/test_array.c
@@ -1,125 +1,130 @@
 #include <node_api.h>
 #include <string.h>
 
-void Test(napi_env env, napi_callback_info info) {
+napi_value Test(napi_env env, napi_callback_info info) {
   napi_status status;
-
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype0;
   status = napi_typeof(env, args[0], &valuetype0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype0 != napi_object) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects an array as first argument.");
-    return;
+    return NULL;
   }
 
   napi_valuetype valuetype1;
   status = napi_typeof(env, args[1], &valuetype1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype1 != napi_number) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects an integer as second argument.");
-    return;
+    return NULL;
   }
 
   napi_value array = args[0];
   int index;
   status = napi_get_value_int32(env, args[1], &index);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   bool isarray;
   status = napi_is_array(env, array, &isarray);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (isarray) {
     uint32_t size;
     status = napi_get_array_length(env, array, &size);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     if (index >= (int)(size)) {
       napi_value str;
       status = napi_create_string_utf8(env, "Index out of bound!", -1, &str);
-      if (status != napi_ok) return;
+      if (status != napi_ok) return NULL;
 
-      status = napi_set_return_value(env, info, str);
-      if (status != napi_ok) return;
+      return str;
     } else if (index < 0) {
       napi_throw_type_error(env, "Invalid index. Expects a positive integer.");
     } else {
       napi_value ret;
       status = napi_get_element(env, array, index, &ret);
-      if (status != napi_ok) return;
+      if (status != napi_ok) return NULL;
 
-      status = napi_set_return_value(env, info, ret);
-      if (status != napi_ok) return;
+      return ret;
     }
   }
+  
+  return NULL;
 }
 
-void New(napi_env env, napi_callback_info info) {
+napi_value New(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_object) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects an array as first argument.");
-    return;
+    return NULL;
   }
 
   napi_value ret;
   status = napi_create_array(env, &ret);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   uint32_t i, length;
   status = napi_get_array_length(env, args[0], &length);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   for (i = 0; i < length; i++) {
     napi_value e;
     status = napi_get_element(env, args[0], i, &e);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     status = napi_set_element(env, ret, i, e);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
   }
 
-  status = napi_set_return_value(env, info, ret);
-  if (status != napi_ok) return;
+  return ret;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -3,75 +3,93 @@
 static double value_ = 1;
 napi_ref constructor_;
 
-void GetValue(napi_env env, napi_callback_info info) {
+napi_value GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 0;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    NULL,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 0) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
 
   napi_value number;
   status = napi_create_number(env, value_, &number);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, number);
-  if (status != napi_ok) return;
+  return number;
 }
 
-void SetValue(napi_env env, napi_callback_info info) {
+napi_value SetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
 
-  napi_value arg;
-  status = napi_get_cb_args(env, info, &arg, 1);
-  if (status != napi_ok) return;
+  status = napi_get_value_double(env, args[0], &value_);
+  if (status != napi_ok) return NULL;
 
-  status = napi_get_value_double(env, arg, &value_);
-  if (status != napi_ok) return;
+  return NULL;
 }
 
-void Echo(napi_env env, napi_callback_info info) {
+napi_value Echo(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
 
-  napi_value arg;
-  status = napi_get_cb_args(env, info, &arg, 1);
-  if (status != napi_ok) return;
-
-  status = napi_set_return_value(env, info, arg);
-  if (status != napi_ok) return;
+  return args[0];
 }
 
-void New(napi_env env, napi_callback_info info) {
+napi_value New(napi_env env, napi_callback_info info) {
   napi_status status;
+  
+  napi_value _this;
+  size_t argc = 0;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    NULL,
+    NULL,
+    &_this);
+  if (status != napi_ok) return NULL;
 
-  napi_value jsthis;
-  status = napi_get_cb_this(env, info, &jsthis);
-  if (status != napi_ok) return;
-
-  status = napi_set_return_value(env, info, jsthis);
-  if (status != napi_ok) return;
+  return _this;
 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
@@ -82,11 +100,11 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   if (status != napi_ok) return;
 
   napi_property_descriptor properties[] = {
-      { "echo", Echo, 0, 0, 0, napi_default, 0 },
-      { "accessorValue", 0, GetValue, SetValue, 0, napi_default, 0},
-      { "readwriteValue", 0, 0, 0, number, napi_default, 0 },
-      { "readonlyValue", 0, 0, 0, number, napi_read_only, 0},
-      { "hiddenValue", 0, 0, 0, number, napi_read_only | napi_dont_enum, 0},
+      { "echo", 0, Echo, 0, 0, 0, napi_default, 0 },
+      { "accessorValue", 0, 0, GetValue, SetValue, 0, napi_default, 0},
+      { "readwriteValue", 0, 0, 0, 0, number, napi_default, 0 },
+      { "readonlyValue", 0, 0, 0, 0, number, napi_read_only, 0},
+      { "hiddenValue", 0, 0, 0, 0, number, napi_read_only | napi_dont_enum, 0},
   };
 
   napi_value cons;

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -7,212 +7,282 @@ void ThrowLastError(napi_env env) {
   }
 }
 
-void AsBool(napi_env env, napi_callback_info info) {
+napi_value AsBool(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   bool value;
-  status = napi_get_value_bool(env, input, &value);
+  status = napi_get_value_bool(env, args[0], &value);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
   status = napi_get_boolean(env, value, &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void AsInt32(napi_env env, napi_callback_info info) {
+napi_value AsInt32(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   int32_t value;
-  status = napi_get_value_int32(env, input, &value);
+  status = napi_get_value_int32(env, args[0], &value);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
   status = napi_create_number(env, value, &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void AsUInt32(napi_env env, napi_callback_info info) {
+napi_value AsUInt32(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   uint32_t value;
-  status = napi_get_value_uint32(env, input, &value);
+  status = napi_get_value_uint32(env, args[0], &value);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
   status = napi_create_number(env, value, &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void AsInt64(napi_env env, napi_callback_info info) {
+napi_value AsInt64(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   int64_t value;
-  status = napi_get_value_int64(env, input, &value);
+  status = napi_get_value_int64(env, args[0], &value);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
   status = napi_create_number(env, (double)value, &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void AsDouble(napi_env env, napi_callback_info info) {
+napi_value AsDouble(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   double value;
-  status = napi_get_value_double(env, input, &value);
+  status = napi_get_value_double(env, args[0], &value);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
   status = napi_create_number(env, value, &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void AsString(napi_env env, napi_callback_info info) {
+napi_value AsString(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   char value[100];
-  status = napi_get_value_string_utf8(env, input, value, sizeof(value), NULL);
+  status = napi_get_value_string_utf8(env, args[0], value, sizeof(value), NULL);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
   status = napi_create_string_utf8(env, value, -1, &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void ToBool(napi_env env, napi_callback_info info) {
+napi_value ToBool(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
-  status = napi_coerce_to_bool(env, input, &output);
+  status = napi_coerce_to_bool(env, args[0], &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void ToNumber(napi_env env, napi_callback_info info) {
+napi_value ToNumber(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
-  status = napi_coerce_to_number(env, input, &output);
+  status = napi_coerce_to_number(env, args[0], &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void ToObject(napi_env env, napi_callback_info info) {
+napi_value ToObject(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
-  status = napi_coerce_to_object(env, input, &output);
+  status = napi_coerce_to_object(env, args[0], &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
-void ToString(napi_env env, napi_callback_info info) {
+napi_value ToString(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value input;
-  status = napi_get_cb_args(env, info, &input, 1);
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
   if (status != napi_ok) goto Exit;
 
   napi_value output;
-  status = napi_coerce_to_string(env, input, &output);
+  status = napi_coerce_to_string(env, args[0], &output);
   if (status != napi_ok) goto Exit;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  return output;
 
 Exit:
   if (status != napi_ok) ThrowLastError(env);
+  return NULL;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)     \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor descriptors[] = {

--- a/test/addons-napi/test_error/test_error.cc
+++ b/test/addons-napi/test_error/test_error.cc
@@ -1,26 +1,32 @@
 #include <node_api.h>
 
-void checkError(napi_env e, napi_callback_info info) {
+napi_value checkError(napi_env env, napi_callback_info info) {
   napi_status status;
-  napi_value jsError;
 
-  status = napi_get_cb_args(e, info, &jsError, 1);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   bool r;
-  status = napi_is_error(e, jsError, &r);
-  if (status != napi_ok) return;
+  status = napi_is_error(env, args[0], &r);
+  if (status != napi_ok) return NULL;
 
   napi_value result;
-  status = napi_get_boolean(e, r, &result);
-  if (status != napi_ok) return;
+  status = napi_get_boolean(env, r, &result);
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(e, info, result);
-  if (status != napi_ok) return;
+  return result;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_exception/test_exception.c
+++ b/test/addons-napi/test_exception/test_exception.c
@@ -2,61 +2,76 @@
 
 static bool exceptionWasPending = false;
 
-void returnException(napi_env env, napi_callback_info info) {
+napi_value returnException(napi_env env, napi_callback_info info) {
   napi_status status;
-  napi_value jsFunction;
 
-  status = napi_get_cb_args(env, info, &jsFunction, 1);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value global;
   status = napi_get_global(env, &global);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value result;
-  status = napi_call_function(env, global, jsFunction, 0, 0, &result);
+  status = napi_call_function(env, global, args[0], 0, 0, &result);
   if (status ==  napi_pending_exception) {
     napi_value ex;
     status = napi_get_and_clear_last_exception(env, &ex);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
-    status = napi_set_return_value(env, info, ex);
-    if (status != napi_ok) return;
+    return ex;
   }
+
+  return NULL;
 }
 
-void allowException(napi_env env, napi_callback_info info) {
+napi_value allowException(napi_env env, napi_callback_info info) {
   napi_status status;
-  napi_value jsFunction;
 
-  status = napi_get_cb_args(env, info, &jsFunction, 1);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   napi_value global;
   status = napi_get_global(env, &global);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value result;
-  status = napi_call_function(env, global, jsFunction, 0, 0, &result);
+  status = napi_call_function(env, global, args[0], 0, 0, &result);
   // Ignore status and check napi_is_exception_pending() instead.
 
   status = napi_is_exception_pending(env, &exceptionWasPending);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
+  return NULL;
 }
 
-void wasPending(napi_env env, napi_callback_info info) {
+napi_value wasPending(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value result;
   status = napi_get_boolean(env, exceptionWasPending, &result);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, result);
-  if (status != napi_ok) return;
+  return result;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_function/test_function.c
+++ b/test/addons-napi/test_function/test_function.c
@@ -1,28 +1,31 @@
 #include <node_api.h>
 
-void Test(napi_env env, napi_callback_info info) {
+napi_value Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 10;
+  napi_value args[10];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[10];
-  status = napi_get_cb_args(env, info, args, 10);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_function) {
     napi_throw_type_error(env, "Wrong type of argments. Expects a function.");
-    return;
+    return NULL;
   }
 
   napi_value function = args[0];
@@ -31,14 +34,13 @@ void Test(napi_env env, napi_callback_info info) {
 
   napi_value global;
   status = napi_get_global(env, &global);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value result;
   status = napi_call_function(env, global, function, argc, argv, &result);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, result);
-  if (status != napi_ok) return;
+  return result;
 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {

--- a/test/addons-napi/test_instanceof/test_instanceof.c
+++ b/test/addons-napi/test_instanceof/test_instanceof.c
@@ -1,28 +1,33 @@
 #include <node_api.h>
 #include <stdio.h>
 
-void doInstanceOf(napi_env env, napi_callback_info info) {
+napi_value doInstanceOf(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  napi_value arguments[2];
-
-  status = napi_get_cb_args(env, info, arguments, 2);
-  if (status != napi_ok) return;
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   bool instanceof;
-  status = napi_instanceof(env, arguments[0], arguments[1], &instanceof);
-  if (status != napi_ok) return;
+  status = napi_instanceof(env, args[0], args[1], &instanceof);
+  if (status != napi_ok) return NULL;
 
   napi_value result;
   status = napi_get_boolean(env, instanceof, &result);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, result);
-  if (status != napi_ok) return;
+  return result;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_number/test_number.c
+++ b/test/addons-napi/test_number/test_number.c
@@ -1,44 +1,46 @@
 #include <node_api.h>
 
-void Test(napi_env env, napi_callback_info info) {
+napi_value Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_number) {
     napi_throw_type_error(env, "Wrong type of argments. Expects a number.");
-    return;
+    return NULL;
   }
 
   double input;
   status = napi_get_value_double(env, args[0], &input);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output;
   status = napi_create_number(env, input, &output);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) return;
+  return output;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_object/test_object.c
+++ b/test/addons-napi/test_object/test_object.c
@@ -1,231 +1,241 @@
 #include <node_api.h>
 
-void Get(napi_env env, napi_callback_info info) {
+napi_value Get(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype0;
   status = napi_typeof(env, args[0], &valuetype0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype0 != napi_object) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects an object as first argument.");
-    return;
+    return NULL;
   }
 
   napi_valuetype valuetype1;
   status = napi_typeof(env, args[1], &valuetype1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype1 != napi_string && valuetype1 != napi_symbol) {
     napi_throw_type_error(env,
         "Wrong type of argments. Expects a string or symbol as second.");
-    return;
+    return NULL;
   }
 
   napi_value object = args[0];
   napi_value output;
   status = napi_get_property(env, object, args[1], &output);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) return;
+  return output;
 }
 
-void Set(napi_env env, napi_callback_info info) {
+napi_value Set(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 3;
+  napi_value args[3];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 3) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[3];
-  status = napi_get_cb_args(env, info, args, 3);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype0;
   status = napi_typeof(env, args[0], &valuetype0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype0 != napi_object) {
     napi_throw_type_error(env,
         "Wrong type of argments. Expects an object as first argument.");
-    return;
+    return NULL;
   }
 
   napi_valuetype valuetype1;
   status = napi_typeof(env, args[1], &valuetype1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype1 != napi_string && valuetype1 != napi_symbol) {
     napi_throw_type_error(env,
         "Wrong type of argments. Expects a string or symbol as second.");
-    return;
+    return NULL;
   }
 
   napi_value object = args[0];
   status = napi_set_property(env, object, args[1], args[2]);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value valuetrue;
   status = napi_get_boolean(env, true, &valuetrue);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, valuetrue);
-  if (status != napi_ok) return;
+  return valuetrue;
 }
 
-void Has(napi_env env, napi_callback_info info) {
+napi_value Has(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype0;
   status = napi_typeof(env, args[0], &valuetype0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype0 != napi_object) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects an object as first argument.");
-    return;
+    return NULL;
   }
 
   napi_valuetype valuetype1;
   status = napi_typeof(env, args[1], &valuetype1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype1 != napi_string && valuetype1 != napi_symbol) {
     napi_throw_type_error(env,
         "Wrong type of argments. Expects a string or symbol as second.");
-    return;
+    return NULL;
   }
 
   napi_value obj = args[0];
   bool has_property;
   status = napi_has_property(env, obj, args[1], &has_property);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value ret;
   status = napi_get_boolean(env, has_property, &ret);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, ret);
-  if (status != napi_ok) return;
+  return ret;
 }
 
-void New(napi_env env, napi_callback_info info) {
+napi_value New(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value ret;
   status = napi_create_object(env, &ret);
+  if (status != napi_ok) return NULL;
 
   napi_value num;
   status = napi_create_number(env, 987654321, &num);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   status = napi_set_named_property(env, ret, "test_number", num);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value str;
   status = napi_create_string_utf8(env, "test string", -1, &str);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   status = napi_set_named_property(env, ret, "test_string", str);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, ret);
-  if (status != napi_ok) return;
+  return ret;
 }
 
-void Inflate(napi_env env, napi_callback_info info) {
+napi_value Inflate(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_object) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects an object as first argument.");
-    return;
+    return NULL;
   }
 
   napi_value obj = args[0];
 
   napi_value propertynames;
   status = napi_get_propertynames(env, obj, &propertynames);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   uint32_t i, length;
   status = napi_get_array_length(env, propertynames, &length);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   for (i = 0; i < length; i++) {
     napi_value property_str;
     status = napi_get_element(env, propertynames, i, &property_str);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     napi_value value;
     status = napi_get_property(env, obj, property_str, &value);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     double double_val;
     status = napi_get_value_double(env, value, &double_val);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     status = napi_create_number(env, double_val + 1, &value);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     status = napi_set_property(env, obj, property_str, value);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
   }
-  status = napi_set_return_value(env, info, obj);
+
+  return obj;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -2,64 +2,75 @@
 
 static double value_ = 1;
 
-void GetValue(napi_env env, napi_callback_info info) {
+napi_value GetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 0;
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    NULL,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 0) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
 
   napi_value number;
   status = napi_create_number(env, value_, &number);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, number);
-  if (status != napi_ok) return;
+  return number;
 }
 
-void SetValue(napi_env env, napi_callback_info info) {
+napi_value SetValue(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
 
-  napi_value arg;
-  status = napi_get_cb_args(env, info, &arg, 1);
-  if (status != napi_ok) return;
-
-  status = napi_get_value_double(env, arg, &value_);
-  if (status != napi_ok) return;
+  status = napi_get_value_double(env, args[0], &value_);
+  if (status != napi_ok) return NULL;
+  return NULL;
 }
 
-void Echo(napi_env env, napi_callback_info info) {
+napi_value Echo(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
 
-  napi_value arg;
-  status = napi_get_cb_args(env, info, &arg, 1);
-  if (status != napi_ok) return;
-
-  status = napi_set_return_value(env, info, arg);
-  if (status != napi_ok) return;
+  return args[0];
 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
@@ -70,11 +81,11 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   if (status != napi_ok) return;
 
   napi_property_descriptor properties[] = {
-      { "echo", Echo, 0, 0, 0, napi_default, 0 },
-      { "accessorValue", 0, GetValue, SetValue, 0, napi_default, 0 },
-      { "readwriteValue", 0, 0, 0, number, napi_default, 0 },
-      { "readonlyValue", 0, 0, 0, number, napi_read_only, 0 },
-      { "hiddenValue", 0, 0, 0, number, napi_read_only | napi_dont_enum, 0 },
+      { "echo", 0, Echo, 0, 0, 0, napi_default, 0 },
+      { "accessorValue", 0, 0, GetValue, SetValue, 0, napi_default, 0 },
+      { "readwriteValue", 0, 0, 0, 0, number, napi_default, 0 },
+      { "readonlyValue", 0, 0, 0, 0, number, napi_read_only, 0 },
+      { "hiddenValue", 0, 0, 0, 0, number, napi_read_only | napi_dont_enum, 0 },
   };
 
   status = napi_define_properties(

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -1,28 +1,31 @@
 #include <node_api.h>
 
-void Copy(napi_env env, napi_callback_info info) {
+napi_value Copy(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_string) {
     napi_throw_type_error(env, "Wrong type of argments. Expects a string.");
-    return;
+    return NULL;
   }
 
   char buffer[128];
@@ -30,92 +33,95 @@ void Copy(napi_env env, napi_callback_info info) {
 
   status =
       napi_get_value_string_utf8(env, args[0], buffer, buffer_size, NULL);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output;
   status = napi_create_string_utf8(env, buffer, -1, &output);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) return;
+  return output;
 }
 
-void Length(napi_env env, napi_callback_info info) {
+napi_value Length(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_string) {
     napi_throw_type_error(env, "Wrong type of argments. Expects a string.");
-    return;
+    return NULL;
   }
 
   size_t length;
   status = napi_get_value_string_length(env, args[0], &length);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output;
   status = napi_create_number(env, (double)length, &output);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) return;
+  return output;
 }
 
-void Utf8Length(napi_env env, napi_callback_info info) {
+napi_value Utf8Length(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_string) {
     napi_throw_type_error(env, "Wrong type of argments. Expects a string.");
-    return;
+    return NULL;
   }
 
   size_t length;
   status = napi_get_value_string_utf8(env, args[0], NULL, 0, &length);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output;
   status = napi_create_number(env, (double)length, &output);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) return;
+  return output;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_symbol/test_symbol.c
+++ b/test/addons-napi/test_symbol/test_symbol.c
@@ -1,28 +1,31 @@
 #include <node_api.h>
 
-void Test(napi_env env, napi_callback_info info) {
+napi_value Test(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc < 1) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype;
   status = napi_typeof(env, args[0], &valuetype);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype != napi_symbol) {
     napi_throw_type_error(env, "Wrong type of argments. Expects a symbol.");
-    return;
+    return NULL;
   }
 
   char buffer[128];
@@ -30,54 +33,52 @@ void Test(napi_env env, napi_callback_info info) {
 
   status =
       napi_get_value_string_utf8(env, args[0], buffer, buffer_size, NULL);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output;
   status = napi_create_string_utf8(env, buffer, -1, &output);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) return;
+  return output;
 }
 
-void New(napi_env env, napi_callback_info info) {
+napi_value New(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 1;
+  napi_value args[1];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
+  napi_value description = NULL;
   if (argc >= 1) {
-    napi_value args[1];
-    napi_get_cb_args(env, info, args, 1);
-
     napi_valuetype valuetype;
     status = napi_typeof(env, args[0], &valuetype);
-    if (status != napi_ok) return;
+    if (status != napi_ok) return NULL;
 
     if (valuetype != napi_string) {
       napi_throw_type_error(env, "Wrong type of argments. Expects a string.");
-      return;
+      return NULL;
     }
 
-    napi_value symbol;
-    status = napi_create_symbol(env, args[0], &symbol);
-    if (status != napi_ok) return;
-
-    status = napi_set_return_value(env, info, symbol);
-    if (status != napi_ok) return;
-  } else {
-    napi_value symbol;
-    status = napi_create_symbol(env, NULL, &symbol);
-    if (status != napi_ok) return;
-
-    status = napi_set_return_value(env, info, symbol);
-    if (status != napi_ok) return;
+    description = args[0];
   }
+
+  napi_value symbol;
+  status = napi_create_symbol(env, description, &symbol);
+  if (status != napi_ok) return NULL;
+
+  return symbol;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -1,58 +1,61 @@
 #include <node_api.h>
 #include <string.h>
 
-void Multiply(napi_env env, napi_callback_info info) {
+napi_value Multiply(napi_env env, napi_callback_info info) {
   napi_status status;
 
-  size_t argc;
-  status = napi_get_cb_args_length(env, info, &argc);
-  if (status != napi_ok) return;
+  size_t argc = 2;
+  napi_value args[2];
+  status = napi_get_cb_info(
+    env,
+    info,
+    &argc,
+    args,
+    NULL,
+    NULL);
+  if (status != napi_ok) return NULL;
 
   if (argc != 2) {
     napi_throw_type_error(env, "Wrong number of arguments");
-    return;
+    return NULL;
   }
-
-  napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
 
   napi_valuetype valuetype0;
   status = napi_typeof(env, args[0], &valuetype0);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype0 != napi_object) {
     napi_throw_type_error(
         env,
         "Wrong type of argments. Expects a typed array as first argument.");
-    return;
+    return NULL;
   }
 
   napi_value input_array = args[0];
   bool istypedarray;
   status = napi_is_typedarray(env, input_array, &istypedarray);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (!istypedarray) {
     napi_throw_type_error(
         env,
         "Wrong type of argments. Expects a typed array as first argument.");
-    return;
+    return NULL;
   }
 
   napi_valuetype valuetype1;
   status = napi_typeof(env, args[1], &valuetype1);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (valuetype1 != napi_number) {
     napi_throw_type_error(
         env, "Wrong type of argments. Expects a number as second argument.");
-    return;
+    return NULL;
   }
 
   double multiplier;
   status = napi_get_value_double(env, args[1], &multiplier);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_typedarray_type type;
   napi_value input_buffer;
@@ -60,23 +63,23 @@ void Multiply(napi_env env, napi_callback_info info) {
   size_t i, length;
   status = napi_get_typedarray_info(
       env, input_array, &type, &length, NULL, &input_buffer, &byte_offset);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   void* data;
   size_t byte_length;
   status = napi_get_arraybuffer_info(env, input_buffer, &data, &byte_length);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output_buffer;
   void* output_ptr = NULL;
   status =
       napi_create_arraybuffer(env, byte_length, &output_ptr, &output_buffer);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output_array;
   status = napi_create_typedarray(
       env, type, length, output_buffer, byte_offset, &output_array);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   if (type == napi_uint8) {
     uint8_t* input_bytes = (uint8_t*)(data) + byte_offset;
@@ -92,14 +95,13 @@ void Multiply(napi_env env, napi_callback_info info) {
     }
   } else {
     napi_throw_error(env, "Typed array was of a type not expected by test.");
-    return;
+    return NULL;
   }
 
-  status = napi_set_return_value(env, info, output_array);
-  if (status != napi_ok) return;
+  return output_array;
 }
 
-void External(napi_env env, napi_callback_info info) {
+napi_value External(napi_env env, napi_callback_info info) {
   static int8_t externalData[] = {0, 1, 2};
 
   napi_value output_buffer;
@@ -110,7 +112,7 @@ void External(napi_env env, napi_callback_info info) {
       NULL,  // finalize_callback
       NULL,  // finalize_hint
       &output_buffer);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
   napi_value output_array;
   status = napi_create_typedarray(env,
@@ -119,14 +121,13 @@ void External(napi_env env, napi_callback_info info) {
                                   output_buffer,
                                   0,
                                   &output_array);
-  if (status != napi_ok) return;
+  if (status != napi_ok) return NULL;
 
-  status = napi_set_return_value(env, info, output_array);
-  if (status != napi_ok) return;
+  return output_array;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
-  { name, func, 0, 0, 0, napi_default, 0 }
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_status status;


### PR DESCRIPTION
Change ```napi_callback``` to return ```napi_value``` instead of requiring the callback to manually call ```napi_set_return_value```.

When we invoke the callback, we will check the return value and call ```SetReturnValue``` ourselves. If the callback returns ```NULL```, we don't set the return value in v8 which would have the same effect as previously if the callback didn't call ```napi_set_return_value```. Seems to be a more natural way to handle return values from callbacks. As a consequence, remove ```napi_set_return_value```.

Add a ```napi_value``` to ```napi_property_descriptor``` to support string values which couldn't be passed in the ```utf8name``` parameter or symbols as property names. Class names, however, cannot be symbols so this ```napi_value``` must be a string type in that case.

Remove all of the ```napi_callback_info``` helpers except for ```napi_get_cb_info``` and make all the parameters to ```napi_get_cb_info``` optional except for argc.

Update all the test collateral according to these changes.