### PR TITLE
Updates for review feedback

### DIFF
--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -17,8 +17,11 @@ typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_callback_info__ *napi_callback_info;
 
-typedef void (*napi_callback)(napi_env, napi_callback_info);
-typedef void (*napi_finalize)(void* finalize_data, void* finalize_hint);
+typedef void (*napi_callback)(napi_env env,
+                              napi_callback_info info);
+typedef void (*napi_finalize)(napi_env env,
+                              void* finalize_data,
+                              void* finalize_hint);
 
 typedef enum {
   napi_default = 0,

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -1,38 +1,36 @@
 #include <node_api.h>
 
-void RunCallback(napi_env env, const napi_callback_info info) {
-  napi_status status;
+#define NAPI_CALL(theCall)                                                \
+  if (theCall != napi_ok) {                                               \
+    const char* errorMessage = napi_get_last_error_info()->error_message; \
+    errorMessage = errorMessage ? errorMessage : "empty error message";   \
+    napi_throw_error((env), errorMessage);                                \
+    return;                                                               \
+  }
 
+void RunCallback(napi_env env, napi_callback_info info) {
   napi_value args[1];
-  status = napi_get_cb_args(env, info, args, 1);
-  if (status != napi_ok) return;
+  NAPI_CALL(napi_get_cb_args(env, info, args, 1));
 
   napi_value cb = args[0];
 
   napi_value argv[1];
-  status = napi_create_string_utf8(env, "hello world", -1, argv);
-  if (status != napi_ok) return;
+  NAPI_CALL(napi_create_string_utf8(env, "hello world", -1, argv));
 
   napi_value global;
-  status = napi_get_global(env, &global);
-  if (status != napi_ok) return;
+  NAPI_CALL(napi_get_global(env, &global));
 
-  status = napi_call_function(env, global, cb, 1, argv, NULL);
-  if (status != napi_ok) return;
+  NAPI_CALL(napi_call_function(env, global, cb, 1, argv, NULL));
 }
 
-void RunCallbackWithRecv(napi_env env, const napi_callback_info info) {
-  napi_status status;
-
+void RunCallbackWithRecv(napi_env env, napi_callback_info info) {
   napi_value args[2];
-  status = napi_get_cb_args(env, info, args, 2);
-  if (status != napi_ok) return;
+  NAPI_CALL(napi_get_cb_args(env, info, args, 2));
 
   napi_value cb = args[0];
   napi_value recv = args[1];
 
-  status = napi_call_function(env, recv, cb, 0, NULL, NULL);
-  if (status != napi_ok) return;
+  NAPI_CALL(napi_call_function(env, recv, cb, 0, NULL, NULL));
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \

--- a/test/addons-napi/3_callbacks/test.js
+++ b/test/addons-napi/3_callbacks/test.js
@@ -7,14 +7,9 @@ addon.RunCallback(function(msg) {
   assert.strictEqual(msg, 'hello world');
 });
 
-const global = function() { return this; }.apply();
-
 function testRecv(desiredRecv) {
   addon.RunCallbackWithRecv(function() {
-    assert.strictEqual(this,
-                       (desiredRecv === undefined ||
-                        desiredRecv === null) ?
-                       global : desiredRecv);
+    assert.strictEqual(this, desiredRecv);
   }, desiredRecv);
 }
 

--- a/test/addons-napi/4_object_factory/binding.c
+++ b/test/addons-napi/4_object_factory/binding.c
@@ -1,6 +1,6 @@
 #include <node_api.h>
 
-void CreateObject(napi_env env, const napi_callback_info info) {
+void CreateObject(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value args[1];

--- a/test/addons-napi/4_object_factory/test.js
+++ b/test/addons-napi/4_object_factory/test.js
@@ -5,4 +5,4 @@ const addon = require(`./build/${common.buildType}/binding`);
 
 const obj1 = addon('hello');
 const obj2 = addon('world');
-assert.strictEqual(obj1.msg + ' ' + obj2.msg, 'hello world');
+assert.strictEqual(`${obj1.msg} ${obj2.msg}`, 'hello world');

--- a/test/addons-napi/6_object_wrap/myobject.cc
+++ b/test/addons-napi/6_object_wrap/myobject.cc
@@ -7,8 +7,10 @@ MyObject::MyObject(double value)
 
 MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
 
-void MyObject::Destructor(void* nativeObject, void* /*finalize_hint*/) {
-  reinterpret_cast<MyObject*>(nativeObject)->~MyObject();
+void MyObject::Destructor(
+  napi_env env, void* nativeObject, void* /*finalize_hint*/) {
+  MyObject* obj = static_cast<MyObject*>(nativeObject);
+  delete obj;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
@@ -67,7 +69,7 @@ void MyObject::New(napi_env env, napi_callback_info info) {
     obj->env_ = env;
     status = napi_wrap(env,
                        jsthis,
-                       reinterpret_cast<void*>(obj),
+                       obj,
                        MyObject::Destructor,
                        nullptr,  // finalize_hint
                        &obj->wrapper_);

--- a/test/addons-napi/6_object_wrap/myobject.h
+++ b/test/addons-napi/6_object_wrap/myobject.h
@@ -6,7 +6,7 @@
 class MyObject {
  public:
   static void Init(napi_env env, napi_value exports);
-  static void Destructor(void* nativeObject, void* finalize_hint);
+  static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
 
  private:
   explicit MyObject(double value_ = 0);

--- a/test/addons-napi/7_factory_wrap/myobject.cc
+++ b/test/addons-napi/7_factory_wrap/myobject.cc
@@ -4,8 +4,11 @@ MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
 
 MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
 
-void MyObject::Destructor(void* nativeObject, void* /*finalize_hint*/) {
-  reinterpret_cast<MyObject*>(nativeObject)->~MyObject();
+void MyObject::Destructor(napi_env env,
+                          void* nativeObject,
+                          void* /*finalize_hint*/) {
+  MyObject* obj = static_cast<MyObject*>(nativeObject);
+  delete obj;
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
@@ -57,7 +60,7 @@ void MyObject::New(napi_env env, napi_callback_info info) {
   obj->env_ = env;
   status = napi_wrap(env,
                      jsthis,
-                     reinterpret_cast<void*>(obj),
+                     obj,
                      MyObject::Destructor,
                      nullptr, /* finalize_hint */
                      &obj->wrapper_);

--- a/test/addons-napi/7_factory_wrap/myobject.h
+++ b/test/addons-napi/7_factory_wrap/myobject.h
@@ -6,7 +6,7 @@
 class MyObject {
  public:
   static napi_status Init(napi_env env);
-  static void Destructor(void* nativeObject, void* /*finalize_hint*/);
+  static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
   static napi_status NewInstance(napi_env env,
                                  napi_value arg,
                                  napi_value* instance);

--- a/test/addons-napi/8_passing_wrapped/myobject.cc
+++ b/test/addons-napi/8_passing_wrapped/myobject.cc
@@ -4,8 +4,10 @@ MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
 
 MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
 
-void MyObject::Destructor(void* nativeObject, void* /*finalize_hint*/) {
-  reinterpret_cast<MyObject*>(nativeObject)->~MyObject();
+void MyObject::Destructor(
+  napi_env env, void* nativeObject, void* /*finalize_hint*/) {
+  MyObject* obj = static_cast<MyObject*>(nativeObject);
+  delete obj;
 }
 
 napi_ref MyObject::constructor;
@@ -50,7 +52,7 @@ void MyObject::New(napi_env env, napi_callback_info info) {
   obj->env_ = env;
   status = napi_wrap(env,
                      jsthis,
-                     reinterpret_cast<void*>(obj),
+                     obj,
                      MyObject::Destructor,
                      nullptr,  // finalize_hint
                      &obj->wrapper_);

--- a/test/addons-napi/8_passing_wrapped/myobject.h
+++ b/test/addons-napi/8_passing_wrapped/myobject.h
@@ -6,7 +6,7 @@
 class MyObject {
  public:
   static napi_status Init(napi_env env);
-  static void Destructor(void* nativeObject, void* finalize_hint);
+  static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
   static napi_status NewInstance(napi_env env,
                                  napi_value arg,
                                  napi_value* instance);

--- a/test/addons-napi/test_array/test.js
+++ b/test/addons-napi/test_array/test.js
@@ -22,11 +22,12 @@ const array = [
 assert.strictEqual(test_array.Test(array, array.length + 1),
                    'Index out of bound!');
 
-try {
-  test_array.Test(array, -2);
-} catch (err) {
-  assert.strictEqual(err.message, 'Invalid index. Expects a positive integer.');
-}
+assert.throws(
+  () => {
+    test_array.Test(array, -2);
+  },
+  /Invalid index. Expects a positive integer./
+);
 
 array.forEach(function(element, index) {
   assert.strictEqual(test_array.Test(array, index), element);

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -12,7 +12,7 @@
 
 #define NAPI_CALL(env, theCall)                                           \
   if (theCall != napi_ok) {                                               \
-    const char *errorMessage = napi_get_last_error_info()->error_message; \
+    const char* errorMessage = napi_get_last_error_info()->error_message; \
     errorMessage = errorMessage ? errorMessage : "empty error message";   \
     napi_throw_error((env), errorMessage);                                \
     return;                                                               \
@@ -22,27 +22,29 @@ static const char theText[] =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
 static int deleterCallCount = 0;
-static void deleteTheText(void *data, void* finalize_hint) {
+static void deleteTheText(napi_env env, void* data, void* finalize_hint) {
+  JS_ASSERT(env, data != NULL && strcmp(data, theText) == 0, "invalid data");
   (void)finalize_hint;
   free(data);
   deleterCallCount++;
 }
 
-static void noopDeleter(void *data, void* finalize_hint) {
+static void noopDeleter(napi_env env, void* data, void* finalize_hint) {
+  JS_ASSERT(env, data != NULL && strcmp(data, theText) == 0, "invalid data");
   (void)finalize_hint;
   deleterCallCount++;
 }
 
 void newBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
-  char *theCopy;
+  char* theCopy;
   const unsigned int kBufferSize = sizeof(theText);
 
   NAPI_CALL(env,
             napi_create_buffer(
                 env,
                 sizeof(theText),
-                (void **)(&theCopy),
+                (void**)(&theCopy),
                 &theBuffer));
   JS_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   memcpy(theCopy, theText, kBufferSize);
@@ -51,7 +53,7 @@ void newBuffer(napi_env env, napi_callback_info info) {
 
 void newExternalBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
-  char *theCopy = strdup(theText);
+  char* theCopy = strdup(theText);
   JS_ASSERT(env, theCopy, "Failed to copy static text for newExternalBuffer");
   NAPI_CALL(env,
             napi_create_external_buffer(
@@ -102,13 +104,13 @@ void bufferInfo(napi_env env, napi_callback_info info) {
   JS_ASSERT(env, argc == 1, "Wrong number of arguments");
   napi_value theBuffer, returnValue;
   NAPI_CALL(env, napi_get_cb_args(env, info, &theBuffer, 1));
-  char *bufferData;
+  char* bufferData;
   size_t bufferLength;
   NAPI_CALL(env,
             napi_get_buffer_info(
                 env,
                 theBuffer,
-                (void **)(&bufferData),
+                (void**)(&bufferData),
                 &bufferLength));
   NAPI_CALL(env, napi_get_boolean(env,
     !strcmp(bufferData, theText) && bufferLength == sizeof(theText),
@@ -122,7 +124,7 @@ void staticBuffer(napi_env env, napi_callback_info info) {
       env,
       napi_create_external_buffer(env,
                                   sizeof(theText),
-                                  (void *)theText,
+                                  (void*)theText,
                                   noopDeleter,
                                   NULL,  // finalize_hint
                                   &theBuffer));

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -12,20 +12,20 @@ void AsBool(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   bool value;
   status = napi_get_value_bool(env, input, &value);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_get_boolean(env, value, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -34,20 +34,20 @@ void AsInt32(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   int32_t value;
   status = napi_get_value_int32(env, input, &value);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_create_number(env, value, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -56,20 +56,20 @@ void AsUInt32(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   uint32_t value;
   status = napi_get_value_uint32(env, input, &value);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_create_number(env, value, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -78,20 +78,20 @@ void AsInt64(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   int64_t value;
   status = napi_get_value_int64(env, input, &value);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_create_number(env, (double)value, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -100,20 +100,20 @@ void AsDouble(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   double value;
   status = napi_get_value_double(env, input, &value);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_create_number(env, value, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -122,20 +122,20 @@ void AsString(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   char value[100];
   status = napi_get_value_string_utf8(env, input, value, sizeof(value), NULL);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_create_string_utf8(env, value, -1, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -144,16 +144,16 @@ void ToBool(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_coerce_to_bool(env, input, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -162,16 +162,16 @@ void ToNumber(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_coerce_to_number(env, input, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -180,16 +180,16 @@ void ToObject(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_coerce_to_object(env, input, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 
@@ -198,16 +198,16 @@ void ToString(napi_env env, napi_callback_info info) {
 
   napi_value input;
   status = napi_get_cb_args(env, info, &input, 1);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   napi_value output;
   status = napi_coerce_to_string(env, input, &output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
   status = napi_set_return_value(env, info, output);
-  if (status != napi_ok) goto Exit;
+  if (status != napi_ok) goto done;
 
-Exit:
+done:
   if (status != napi_ok) ThrowLastError(env);
 }
 

--- a/test/addons-napi/test_exception/test.js
+++ b/test/addons-napi/test_exception/test.js
@@ -17,14 +17,15 @@ assert.strictEqual(theError, returnedError,
                    'Returned error is strictly equal to the thrown error');
 
 // Test that the native side passes the exception through
-try {
-  test_exception.allowException(throwTheError);
-} catch (anError) {
-  caughtError = anError;
-}
-assert.strictEqual(caughtError, theError,
-                   'Thrown exception was allowed to pass through unhindered');
-caughtError = undefined;
+assert.throws(
+  () => {
+    test_exception.allowException(throwTheError);
+  },
+  function(err) {
+    return err === theError;
+  },
+  'Thrown exception was allowed to pass through unhindered'
+);
 
 // Test that the exception thrown above was marked as pending
 // before it was handled on the JS side


### PR DESCRIPTION
 - Add an env parameter to `napi_finalize`
 - Remove unnecessary `reinterpret_cast<>` calls
 - Remove redundant `Maybe.IsNothing()` checks
 - Make function call result parameters optional
 - Wrap internal field pointer values in `v8::External`
 - Fix broken callback tests and add error-checking
 - Other misc test cleanup