### PR TITLE
Redesign async helper APIs

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <vector>
 #include "node_api.h"
+#include "env.h"
 
 namespace v8impl {
 
@@ -627,7 +628,8 @@ const char* error_messages[] = {nullptr,
                                 "A boolean was expected",
                                 "An array was expected",
                                 "Unknown failure",
-                                "An exception is pending"};
+                                "An exception is pending",
+                                "The async work item was cancelled"};
 
 void napi_clear_last_error() {
   static_last_error.error_code = napi_ok;
@@ -2527,4 +2529,137 @@ napi_status napi_get_typedarray_info(napi_env env,
   }
 
   return GET_RETURN_STATUS();
+}
+
+namespace uvimpl {
+
+napi_status ConvertUVErrorCode(int code) {
+  switch (code) {
+  case 0:
+    return napi_ok;
+  case UV_EINVAL:
+    return napi_invalid_arg;
+  case UV_ECANCELED:
+    return napi_cancelled;
+  }
+
+  return napi_generic_failure;
+}
+
+// Wrapper around uv_work_t which calls user-provided callbacks.
+class Work {
+ private:
+  explicit Work(napi_env env,
+                napi_async_execute_callback execute = nullptr,
+                napi_async_complete_callback complete = nullptr,
+                void* data = nullptr)
+    : _env(env),
+    _data(data),
+    _execute(execute),
+    _complete(complete) {
+    _request.data = this;
+  }
+
+  ~Work() { }
+
+ public:
+  static Work* New(napi_env env,
+                   napi_async_execute_callback execute,
+                   napi_async_complete_callback complete,
+                   void* data) {
+    return new Work(env, execute, complete, data);
+  }
+
+  static void Delete(Work* work) {
+    delete work;
+  }
+
+  static void ExecuteCallback(uv_work_t* req) {
+    Work* work = static_cast<Work*>(req->data);
+    work->_execute(work->_env, work->_data);
+  }
+
+  static void CompleteCallback(uv_work_t* req, int status) {
+    Work* work = static_cast<Work*>(req->data);
+
+    if (work->_complete != nullptr) {
+      work->_complete(work->_env, ConvertUVErrorCode(status), work->_data);
+    }
+  }
+
+  uv_work_t* Request() {
+    return &_request;
+  }
+
+ private:
+  napi_env _env;
+  void* _data;
+  uv_work_t _request;
+  napi_async_execute_callback _execute;
+  napi_async_complete_callback _complete;
+};
+
+}  // end of namespace uvimpl
+
+#define CALL_UV(condition)                                              \
+  do {                                                                  \
+    int result = (condition);                                           \
+    napi_status status = uvimpl::ConvertUVErrorCode(result);            \
+    if (status != napi_ok) {                                            \
+      return napi_set_last_error(status, result);                       \
+    }                                                                   \
+  } while (0)
+
+napi_status napi_create_async_work(napi_env env,
+                                   napi_async_execute_callback execute,
+                                   napi_async_complete_callback complete,
+                                   void* data,
+                                   napi_async_work* result) {
+  CHECK_ARG(env);
+  CHECK_ARG(execute);
+  CHECK_ARG(result);
+
+  uvimpl::Work* work = uvimpl::Work::New(env, execute, complete, data);
+
+  *result = reinterpret_cast<napi_async_work>(work);
+
+  return napi_ok;
+}
+
+napi_status napi_delete_async_work(napi_env env, napi_async_work work) {
+  CHECK_ARG(env);
+  CHECK_ARG(work);
+
+  uvimpl::Work::Delete(reinterpret_cast<uvimpl::Work*>(work));
+
+  return napi_ok;
+}
+
+napi_status napi_queue_async_work(napi_env env, napi_async_work work) {
+  CHECK_ARG(env);
+  CHECK_ARG(work);
+
+  // Consider: Encapsulate the uv_loop_t into an opaque pointer parameter
+  uv_loop_t* event_loop = node::Environment::GetCurrent(
+    v8impl::V8IsolateFromJsEnv(env))->event_loop();
+
+  uvimpl::Work* w = reinterpret_cast<uvimpl::Work*>(work);
+
+  CALL_UV(uv_queue_work(event_loop,
+                        w->Request(),
+                        uvimpl::Work::ExecuteCallback,
+                        uvimpl::Work::CompleteCallback));
+
+  return napi_ok;
+}
+
+napi_status napi_cancel_async_work(napi_env env, napi_async_work work) {
+  CHECK_ARG(env);
+  CHECK_ARG(work);
+
+  uvimpl::Work* w = reinterpret_cast<uvimpl::Work*>(work);
+
+  CALL_UV(uv_cancel(reinterpret_cast<uv_req_t*>(w->Request())));
+
+  return napi_ok;
 }

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -474,6 +474,21 @@ NAPI_EXTERN napi_status napi_get_typedarray_info(napi_env env,
                                                  void** data,
                                                  napi_value* arraybuffer,
                                                  size_t* byte_offset);
+
+// Methods to manage simple async operations
+NAPI_EXTERN
+napi_status napi_create_async_work(napi_env env,
+                                   napi_async_execute_callback execute,
+                                   napi_async_complete_callback complete,
+                                   void* data,
+                                   napi_async_work* result);
+NAPI_EXTERN napi_status napi_delete_async_work(napi_env env,
+                                               napi_async_work work);
+NAPI_EXTERN napi_status napi_queue_async_work(napi_env env,
+                                              napi_async_work work);
+NAPI_EXTERN napi_status napi_cancel_async_work(napi_env env,
+                                               napi_async_work work);
+
 EXTERN_C_END
 
 #endif  // SRC_NODE_API_H__

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -16,12 +16,7 @@ typedef struct napi_ref__ *napi_ref;
 typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_callback_info__ *napi_callback_info;
-
-typedef void (*napi_callback)(napi_env env,
-                              napi_callback_info info);
-typedef void (*napi_finalize)(napi_env env,
-                              void* finalize_data,
-                              void* finalize_hint);
+typedef struct napi_async_work__ *napi_async_work;
 
 typedef enum {
   napi_default = 0,
@@ -33,18 +28,6 @@ typedef enum {
   // from instance properties. Ignored by napi_define_properties.
   napi_static_property = 1 << 10,
 } napi_property_attributes;
-
-typedef struct {
-  const char* utf8name;
-
-  napi_callback method;
-  napi_callback getter;
-  napi_callback setter;
-  napi_value value;
-
-  napi_property_attributes attributes;
-  void* data;
-} napi_property_descriptor;
 
 typedef enum {
   // ES6 types (corresponds to typeof)
@@ -82,8 +65,32 @@ typedef enum {
   napi_array_expected,
   napi_generic_failure,
   napi_pending_exception,
+  napi_cancelled,
   napi_status_last
 } napi_status;
+
+typedef void (*napi_callback)(napi_env env, 
+                              napi_callback_info info);
+typedef void (*napi_finalize)(napi_env env,
+                              void* finalize_data, 
+                              void* finalize_hint);
+typedef void (*napi_async_execute_callback)(napi_env env, 
+                                            void* data);
+typedef void (*napi_async_complete_callback)(napi_env env,
+                                             napi_status status,
+                                             void* data);
+
+typedef struct {
+  const char* utf8name;
+
+  napi_callback method;
+  napi_callback getter;
+  napi_callback setter;
+  napi_value value;
+
+  napi_property_attributes attributes;
+  void* data;
+} napi_property_descriptor;
 
 typedef struct {
   const char* error_message;

--- a/test/addons-napi/test_async/binding.gyp
+++ b/test/addons-napi/test_async/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_async",
+      "sources": [ "test_async.cc" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_async/test.js
+++ b/test/addons-napi/test_async/test.js
@@ -1,0 +1,10 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const test_async = require(`./build/${common.buildType}/test_async`);
+
+test_async(5, common.mustCall(function(err, val) {
+  assert.strictEqual(err, null);
+  assert.strictEqual(val, 10);
+  process.nextTick(common.mustCall(function() {}));
+}));

--- a/test/addons-napi/test_async/test_async.cc
+++ b/test/addons-napi/test_async/test_async.cc
@@ -1,0 +1,130 @@
+#include <node_api.h>
+
+#if defined _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#define NAPI_CHECK(env, condition, msg)                                   \
+  if (!(condition)) {                                                     \
+    napi_throw_error((env), (msg));                                       \
+    return;                                                               \
+  }
+
+#define NAPI_CALL(env, theCall)                                           \
+  if ((theCall) != napi_ok) {                                             \
+    const napi_extended_error_info* error;                                \
+    napi_get_last_error_info((env), &error);                              \
+    const char *errorMessage = error->error_message;                      \
+    errorMessage = errorMessage ? errorMessage : "empty error message";   \
+    napi_throw_error((env), errorMessage);                                \
+    return;                                                               \
+  }
+
+typedef struct {
+  int32_t _input;
+  int32_t _output;
+  napi_ref _callback;
+  napi_async_work _request;
+} carrier;
+
+carrier theCarrier;
+
+struct AutoHandleScope {
+  AutoHandleScope(napi_env env)
+  : _env(env),
+  _scope(NULL) {
+    napi_open_handle_scope(_env, &_scope);
+  }
+  ~AutoHandleScope() {
+    napi_close_handle_scope(_env, _scope);
+  }
+private:
+  AutoHandleScope() { }
+
+  napi_env _env;
+  napi_handle_scope _scope;
+};
+
+void Execute(napi_env env, void* data) {
+#if defined _WIN32
+  Sleep(1000);
+#else
+  sleep(1);
+#endif
+  carrier* c = static_cast<carrier*>(data);
+  
+  if (c != &theCarrier) {
+    napi_throw_type_error(env, "Wrong data parameter to Execute.");
+    return;
+  }
+  
+  c->_output = c->_input * 2;
+}
+
+void Complete(napi_env env, napi_status status, void* data) {
+  AutoHandleScope scope(env);
+  carrier* c = static_cast<carrier*>(data);
+
+  if (c != &theCarrier) {
+    napi_throw_type_error(env, "Wrong data parameter to Complete.");
+    return;
+  }
+  
+  if (status != napi_ok) {
+    napi_throw_type_error(env, "Execute callback failed.");
+    return;
+  }
+
+  napi_value argv[2];
+  
+  NAPI_CALL(env, napi_get_null(env, &argv[0]));
+  NAPI_CALL(env, napi_create_number(env, c->_output, &argv[1]));
+  napi_value callback;
+  NAPI_CALL(env, napi_get_reference_value(env, c->_callback, &callback));
+  napi_value global;
+  NAPI_CALL(env, napi_get_global(env, &global));
+
+  napi_value result;
+  NAPI_CALL(env, napi_call_function(env, global, callback, 2, argv, &result));
+  
+  NAPI_CALL(env, napi_delete_reference(env, c->_callback));
+  NAPI_CALL(env, napi_delete_async_work(env, c->_request));
+}
+
+void Test(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value argv[2];
+  napi_value _this;
+  void* data;
+  NAPI_CALL(env,
+    napi_get_cb_info(env, info, &argc, argv, &_this, &data));
+  NAPI_CHECK(env, argc >= 2, "Not enough arguments, expected 2.");
+
+  napi_valuetype t;
+  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
+  NAPI_CHECK(env, t == napi_number, "Wrong first argument, integer expected.");
+  NAPI_CALL(env, napi_typeof(env, argv[1], &t));
+  NAPI_CHECK(env, t == napi_function, "Wrong second argument,"
+    " function expected.");
+
+  theCarrier._output = 0;
+
+  NAPI_CALL(env,
+    napi_get_value_int32(env, argv[0], &theCarrier._input));
+  NAPI_CALL(env,
+    napi_create_reference(env, argv[1], 1, &theCarrier._callback));
+  NAPI_CALL(env, napi_create_async_work(
+    env, Execute, Complete, &theCarrier, &theCarrier._request));
+  NAPI_CALL(env,
+    napi_queue_async_work(env, theCarrier._request));
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_value test;
+  NAPI_CALL(env, napi_create_function(env, "Test", Test, NULL, &test));
+  NAPI_CALL(env, napi_set_named_property(env, module, "exports", test));
+}
+
+NAPI_MODULE(addon, Init)


### PR DESCRIPTION
Add error handling for the async helper APIs. At least they all return ```napi_status``` now.

Remove the individual APIs for setting all the pieces of the ```napi_work``` struct opting to just take all the parameters in ```napi_create_async_work```. It doesn't seem like any of the parameters are optional here anyway.
    
Renamed the ```napi_work``` struct to ```napi_async_work``` and replace the struct itself with a class which can better encapsulate the object lifetime and ```uv_work_t``` that we're trying to wrap anyway.
    
Added a ```napi_async_callback``` type for the async helper callbacks instead of taking raw function pointers and make this callback take a ```napi_env``` parameter as well as the ```void* data``` it was already taking.
    
Also added some async unit tests for addons-napi based on the addons/async_hello_world test.