### PR TITLE
napi: create napi_env as a real structure tied to the isolate

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -22,7 +22,12 @@ napi_status napi_set_last_error(napi_env env,
                                 void* engine_reserved = nullptr);
 void napi_clear_last_error(napi_env env);
 
-struct napi_env__ {
+class napi_env__ {
+ public:
+  explicit napi_env__(v8::Isolate* _isolate): isolate(_isolate), last_error() {}
+  ~napi_env__() {
+    last_exception.Reset();
+  }
   v8::Isolate* isolate;
   v8::Persistent<v8::Value> last_exception;
   napi_extended_error_info last_error;
@@ -533,9 +538,7 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
   // some other framework makes use of slot 0? There really seems to be a need
   // for a more robust way of assigning arbitrary data to the isolate.
   if (isolate->GetData(0) == nullptr) {
-    napi_env env = new napi_env__;
-    env->isolate = isolate;
-    napi_clear_last_error(env);
+    napi_env env = new napi_env__(isolate);
     isolate->SetData(0, env);
   }
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -600,38 +600,39 @@ void napi_module_register(napi_module* mod) {
   RETURN_STATUS_IF_FALSE((env), !((maybe).IsNothing()), (status))
 
 // NAPI_PREAMBLE is not wrapped in do..while: try_catch must have function scope
-#define NAPI_PREAMBLE(env)                                            \
-  CHECK_ARG(env, env);                                                \
-  RETURN_STATUS_IF_FALSE(env, env->last_exception.IsEmpty(), \
-                         napi_pending_exception);                     \
-  napi_clear_last_error((env));                                       \
+#define NAPI_PREAMBLE(env)                                       \
+  CHECK_ARG((env), (env));                                       \
+  RETURN_STATUS_IF_FALSE((env), (env)->last_exception.IsEmpty(), \
+                         napi_pending_exception);                \
+  napi_clear_last_error((env));                                  \
   v8impl::TryCatch try_catch((env))
 
 #define CHECK_TO_TYPE(env, type, context, result, src, status)                \
   do {                                                                        \
     auto maybe = v8impl::V8LocalValueFromJsValue((src))->To##type((context)); \
-    CHECK_MAYBE_EMPTY(env, maybe, (status));                                  \
-    result = maybe.ToLocalChecked();                                          \
+    CHECK_MAYBE_EMPTY((env), maybe, (status));                                \
+    (result) = maybe.ToLocalChecked();                                        \
   } while (0)
 
 #define CHECK_TO_OBJECT(env, context, result, src) \
-  CHECK_TO_TYPE(env, Object, context, result, src, napi_object_expected)
+  CHECK_TO_TYPE((env), Object, (context), (result), (src), napi_object_expected)
 
 #define CHECK_TO_STRING(env, context, result, src) \
-  CHECK_TO_TYPE(env, String, context, result, src, napi_string_expected)
+  CHECK_TO_TYPE((env), String, (context), (result), (src), napi_string_expected)
 
 #define CHECK_TO_NUMBER(env, context, result, src) \
-  CHECK_TO_TYPE(env, Number, context, result, src, napi_number_expected)
+  CHECK_TO_TYPE((env), Number, (context), (result), (src), napi_number_expected)
 
-#define CHECK_TO_BOOL(env, context, result, src) \
-  CHECK_TO_TYPE(env, Boolean, context, result, src, napi_boolean_expected)
+#define CHECK_TO_BOOL(env, context, result, src)            \
+  CHECK_TO_TYPE((env), Boolean, (context), (result), (src), \
+    napi_boolean_expected)
 
-#define CHECK_NEW_FROM_UTF8_LEN(env, result, str, len)          \
-  do {                                                              \
-    auto str_maybe = v8::String::NewFromUtf8(                       \
+#define CHECK_NEW_FROM_UTF8_LEN(env, result, str, len)                   \
+  do {                                                                   \
+    auto str_maybe = v8::String::NewFromUtf8(                            \
         (env)->isolate, (str), v8::NewStringType::kInternalized, (len)); \
-    CHECK_MAYBE_EMPTY(env, str_maybe, napi_generic_failure);             \
-    result = str_maybe.ToLocalChecked();                            \
+    CHECK_MAYBE_EMPTY((env), str_maybe, napi_generic_failure);           \
+    result = str_maybe.ToLocalChecked();                                 \
   } while (0)
 
 #define CHECK_NEW_FROM_UTF8(env, result, str) \

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -100,7 +100,8 @@ EXTERN_C_START
 
 NAPI_EXTERN void napi_module_register(napi_module* mod);
 
-NAPI_EXTERN const napi_extended_error_info* napi_get_last_error_info();
+NAPI_EXTERN const napi_extended_error_info* napi_get_last_error_info(
+                                                                  napi_env env);
 
 // Getters for defined singletons
 NAPI_EXTERN napi_status napi_get_undefined(napi_env env, napi_value* result);

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -1,36 +1,36 @@
 #include <node_api.h>
 
-#define NAPI_CALL(theCall)                                                \
-  if (theCall != napi_ok) {                                               \
-    const char* errorMessage = napi_get_last_error_info()->error_message; \
-    errorMessage = errorMessage ? errorMessage : "empty error message";   \
-    napi_throw_error((env), errorMessage);                                \
-    return;                                                               \
+#define NAPI_CALL(env, theCall)                                                \
+  if (theCall != napi_ok) {                                                    \
+    const char* errorMessage = napi_get_last_error_info((env))->error_message; \
+    errorMessage = errorMessage ? errorMessage : "empty error message";        \
+    napi_throw_error((env), errorMessage);                                     \
+    return;                                                                    \
   }
 
 void RunCallback(napi_env env, napi_callback_info info) {
   napi_value args[1];
-  NAPI_CALL(napi_get_cb_args(env, info, args, 1));
+  NAPI_CALL(env, napi_get_cb_args(env, info, args, 1));
 
   napi_value cb = args[0];
 
   napi_value argv[1];
-  NAPI_CALL(napi_create_string_utf8(env, "hello world", -1, argv));
+  NAPI_CALL(env, napi_create_string_utf8(env, "hello world", -1, argv));
 
   napi_value global;
-  NAPI_CALL(napi_get_global(env, &global));
+  NAPI_CALL(env, napi_get_global(env, &global));
 
-  NAPI_CALL(napi_call_function(env, global, cb, 1, argv, NULL));
+  NAPI_CALL(env, napi_call_function(env, global, cb, 1, argv, NULL));
 }
 
 void RunCallbackWithRecv(napi_env env, napi_callback_info info) {
   napi_value args[2];
-  NAPI_CALL(napi_get_cb_args(env, info, args, 2));
+  NAPI_CALL(env, napi_get_cb_args(env, info, args, 2));
 
   napi_value cb = args[0];
   napi_value recv = args[1];
 
-  NAPI_CALL(napi_call_function(env, recv, cb, 0, NULL, NULL));
+  NAPI_CALL(env, napi_call_function(env, recv, cb, 0, NULL, NULL));
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -10,12 +10,12 @@
     return;                                             \
   }
 
-#define NAPI_CALL(env, theCall)                                           \
-  if (theCall != napi_ok) {                                               \
-    const char* errorMessage = napi_get_last_error_info()->error_message; \
-    errorMessage = errorMessage ? errorMessage : "empty error message";   \
-    napi_throw_error((env), errorMessage);                                \
-    return;                                                               \
+#define NAPI_CALL(env, theCall)                                                \
+  if (theCall != napi_ok) {                                                    \
+    const char* errorMessage = napi_get_last_error_info((env))->error_message; \
+    errorMessage = errorMessage ? errorMessage : "empty error message";        \
+    napi_throw_error((env), errorMessage);                                     \
+    return;                                                                    \
   }
 
 static const char theText[] =

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -1,7 +1,7 @@
 #include <node_api.h>
 
 void ThrowLastError(napi_env env) {
-  const napi_extended_error_info* error_info = napi_get_last_error_info();
+  const napi_extended_error_info* error_info = napi_get_last_error_info(env);
   if (error_info->error_code != napi_ok) {
     napi_throw_error(env, error_info->error_message);
   }


### PR DESCRIPTION
1. We define struct napi_env__ to include the isolate, the last
exception, and the info about the last error.

2. We instantiate one struct napi_env__ during module registration, but
only if there isn't one already attached to the isolate, perhaps from
the registration of a pervious module.

3. the last exception and the info about the last error are stored in
the napi_env__ struct which is associated with the isolate via
v8::Isolate::SetData().

Fixes https://github.com/nodejs/abi-stable-node/issues/198