### PR TITLE
napi: add napi_env to napi_get_last_error_info()

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -637,7 +637,8 @@ void napi_clear_last_error() {
   static_last_error.engine_reserved = nullptr;
 }
 
-const napi_extended_error_info* napi_get_last_error_info() {
+const napi_extended_error_info* napi_get_last_error_info(napi_env env) {
+  (void)env;
   static_assert(node::arraysize(error_messages) == napi_status_last,
       "Count of error messages must match count of error values");
   assert(static_last_error.error_code < napi_status_last);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -637,8 +637,20 @@ void napi_clear_last_error() {
   static_last_error.engine_reserved = nullptr;
 }
 
-const napi_extended_error_info* napi_get_last_error_info(napi_env env) {
-  (void)env;
+napi_status napi_set_last_error(napi_status error_code,
+                                uint32_t engine_error_code = 0,
+                                void* engine_reserved = nullptr) {
+  static_last_error.error_code = error_code;
+  static_last_error.engine_error_code = engine_error_code;
+  static_last_error.engine_reserved = engine_reserved;
+
+  return error_code;
+}
+
+napi_status napi_get_last_error_info(napi_env env,
+                                     const napi_extended_error_info** result) {
+  CHECK_ARG(env);
+
   static_assert(node::arraysize(error_messages) == napi_status_last,
       "Count of error messages must match count of error values");
   assert(static_last_error.error_code < napi_status_last);
@@ -648,17 +660,8 @@ const napi_extended_error_info* napi_get_last_error_info(napi_env env) {
   static_last_error.error_message =
       error_messages[static_last_error.error_code];
 
-  return &static_last_error;
-}
-
-napi_status napi_set_last_error(napi_status error_code,
-                                uint32_t engine_error_code = 0,
-                                void* engine_reserved = nullptr) {
-  static_last_error.error_code = error_code;
-  static_last_error.engine_error_code = engine_error_code;
-  static_last_error.engine_reserved = engine_reserved;
-
-  return error_code;
+  *result = &static_last_error;
+  return napi_ok;
 }
 
 napi_status napi_create_function(napi_env env,

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -100,7 +100,8 @@ EXTERN_C_START
 
 NAPI_EXTERN void napi_module_register(napi_module* mod);
 
-NAPI_EXTERN const napi_extended_error_info* napi_get_last_error_info();
+NAPI_EXTERN const napi_extended_error_info* napi_get_last_error_info(
+                                                                  napi_env env);
 
 // Getters for defined singletons
 NAPI_EXTERN napi_status napi_get_undefined(napi_env env, napi_value* result);

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -100,8 +100,9 @@ EXTERN_C_START
 
 NAPI_EXTERN void napi_module_register(napi_module* mod);
 
-NAPI_EXTERN const napi_extended_error_info* napi_get_last_error_info(
-                                                                  napi_env env);
+NAPI_EXTERN napi_status
+napi_get_last_error_info(napi_env env,
+                         const napi_extended_error_info** result);
 
 // Getters for defined singletons
 NAPI_EXTERN napi_status napi_get_undefined(napi_env env, napi_value* result);

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -1,36 +1,36 @@
 #include <node_api.h>
 
-#define NAPI_CALL(theCall)                                                \
-  if ((theCall) != napi_ok) {                                             \
-    const char* errorMessage = napi_get_last_error_info()->error_message; \
-    errorMessage = errorMessage ? errorMessage : "empty error message";   \
-    napi_throw_error((env), errorMessage);                                \
-    return;                                                               \
+#define NAPI_CALL(env, theCall)                                                \
+  if ((theCall) != napi_ok) {                                                  \
+    const char* errorMessage = napi_get_last_error_info((env))->error_message; \
+    errorMessage = errorMessage ? errorMessage : "empty error message";        \
+    napi_throw_error((env), errorMessage);                                     \
+    return;                                                                    \
   }
 
 void RunCallback(napi_env env, napi_callback_info info) {
   napi_value args[1];
-  NAPI_CALL(napi_get_cb_args(env, info, args, 1));
+  NAPI_CALL(env, napi_get_cb_args(env, info, args, 1));
 
   napi_value cb = args[0];
 
   napi_value argv[1];
-  NAPI_CALL(napi_create_string_utf8(env, "hello world", -1, argv));
+  NAPI_CALL(env, napi_create_string_utf8(env, "hello world", -1, argv));
 
   napi_value global;
-  NAPI_CALL(napi_get_global(env, &global));
+  NAPI_CALL(env, napi_get_global(env, &global));
 
-  NAPI_CALL(napi_call_function(env, global, cb, 1, argv, NULL));
+  NAPI_CALL(env, napi_call_function(env, global, cb, 1, argv, NULL));
 }
 
 void RunCallbackWithRecv(napi_env env, napi_callback_info info) {
   napi_value args[2];
-  NAPI_CALL(napi_get_cb_args(env, info, args, 2));
+  NAPI_CALL(env, napi_get_cb_args(env, info, args, 2));
 
   napi_value cb = args[0];
   napi_value recv = args[1];
 
-  NAPI_CALL(napi_call_function(env, recv, cb, 0, NULL, NULL));
+  NAPI_CALL(env, napi_call_function(env, recv, cb, 0, NULL, NULL));
 }
 
 #define DECLARE_NAPI_METHOD(name, func)                          \

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -2,7 +2,9 @@
 
 #define NAPI_CALL(env, theCall)                                                \
   if ((theCall) != napi_ok) {                                                  \
-    const char* errorMessage = napi_get_last_error_info((env))->error_message; \
+    const napi_extended_error_info* error;                                     \
+    napi_get_last_error_info((env), &error);                                   \
+    const char* errorMessage = error->error_message;                           \
     errorMessage = errorMessage ? errorMessage : "empty error message";        \
     napi_throw_error((env), errorMessage);                                     \
     return;                                                                    \

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -10,12 +10,12 @@
     return;                                             \
   }
 
-#define NAPI_CALL(env, theCall)                                           \
-  if ((theCall) != napi_ok) {                                             \
-    const char* errorMessage = napi_get_last_error_info()->error_message; \
-    errorMessage = errorMessage ? errorMessage : "empty error message";   \
-    napi_throw_error((env), errorMessage);                                \
-    return;                                                               \
+#define NAPI_CALL(env, theCall)                                                \
+  if ((theCall) != napi_ok) {                                                  \
+    const char* errorMessage = napi_get_last_error_info((env))->error_message; \
+    errorMessage = errorMessage ? errorMessage : "empty error message";        \
+    napi_throw_error((env), errorMessage);                                     \
+    return;                                                                    \
   }
 
 static const char theText[] =

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -12,7 +12,9 @@
 
 #define NAPI_CALL(env, theCall)                                                \
   if ((theCall) != napi_ok) {                                                  \
-    const char* errorMessage = napi_get_last_error_info((env))->error_message; \
+    const napi_extended_error_info* error;                                     \
+    napi_get_last_error_info((env), &error);                                   \
+    const char* errorMessage = error->error_message;                           \
     errorMessage = errorMessage ? errorMessage : "empty error message";        \
     napi_throw_error((env), errorMessage);                                     \
     return;                                                                    \

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -1,7 +1,7 @@
 #include <node_api.h>
 
 void ThrowLastError(napi_env env) {
-  const napi_extended_error_info* error_info = napi_get_last_error_info();
+  const napi_extended_error_info* error_info = napi_get_last_error_info(env);
   if (error_info->error_code != napi_ok) {
     napi_throw_error(env, error_info->error_message);
   }

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -1,7 +1,8 @@
 #include <node_api.h>
 
 void ThrowLastError(napi_env env) {
-  const napi_extended_error_info* error_info = napi_get_last_error_info(env);
+  const napi_extended_error_info* error_info;
+  napi_get_last_error_info(env, &error_info);
   if (error_info->error_code != napi_ok) {
     napi_throw_error(env, error_info->error_message);
   }


### PR DESCRIPTION
This makes it necessary to pass napi_env to napi_get_last_error_info()
thereby ensuring that errors can be tied to the napi_env in the future.

Re https://github.com/nodejs/abi-stable-node/issues/198