### PR TITLE
Add doc for N-API Abstract Operations APIs

### DIFF
--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -1,7 +1,8 @@
 # N-API - Abstract Operations 
 
 N-API exposes a set of APIs to apply some abstract operations on JavaScript 
-Objects. Some of these operations are documented under [Section 7](https://tc39.github.io/ecma262/#sec-abstract-operations) 
+Objects. Some of these operations are documented under 
+[Section 7](https://tc39.github.io/ecma262/#sec-abstract-operations) 
 of the [ECMAScript Language Specification](https://tc39.github.io/ecma262/).
 
 These APIs allow you to do one of the following:

--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -16,7 +16,7 @@ These APIs allow you to do one of the following:
 ### *napi_coerce_to_bool*
 
 #### Signature
-```
+```C
 napi_status napi_coerce_to_bool(napi_env env, 
                                 napi_value value, 
                                 napi_value* result)
@@ -39,7 +39,7 @@ This API can be re-entrant if getters are defined on the passed in Object.
 ### *napi_coerce_to_number*
 
 #### Signature
-```
+```C
 napi_status napi_coerce_to_number(napi_env env, 
                                   napi_value value, 
                                   napi_value* result)
@@ -62,7 +62,7 @@ This API can be re-entrant if getters are defined on the passed in Object.
 ### *napi_coerce_to_object*
 
 #### Signature
-```
+```C
 napi_status napi_coerce_to_object(napi_env env, 
                                   napi_value value,
                                   napi_value* result)
@@ -85,7 +85,7 @@ This API can be re-entrant if getters are defined on the passed in Object.
 ### *napi_coerce_to_string*
 
 #### Signature
-```
+```C
 napi_status napi_coerce_to_string(napi_env env, 
                                   napi_value value, 
                                   napi_value* result)
@@ -108,7 +108,7 @@ This API can be re-entrant if getters are defined on the passed-in Object.
 ### *napi_typeof*
 
 #### Signature
-```
+```C
 napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
 ```
 
@@ -133,7 +133,7 @@ returned.
 ### *napi_instanceof*
 
 #### Signature
-```
+```C
 napi_status napi_instanceof(napi_env env, 
                             napi_value object, 
                             napi_value constructor, 
@@ -159,7 +159,7 @@ of the ECMAScript Language Specification.
 ### *napi_is_array*
 
 #### Signature
-```
+```C
 napi_status napi_is_array(napi_env env, napi_value value, bool* result)
 ```
 
@@ -179,7 +179,7 @@ of the ECMAScript Language Specification.
 ### *napi_is_arraybuffer*
 
 #### Signature
-```
+```C
 napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result)
 ```
 
@@ -194,7 +194,7 @@ napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result)
 ### *napi_is_buffer*
 
 #### Signature
-```
+```C
 napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 ```
 
@@ -210,7 +210,7 @@ node-Buffer
 ### *napi_is_error*
 
 #### Signature
-```
+```C
 napi_status napi_is_error(napi_env env, napi_value value, bool* result)
 ```
 
@@ -225,7 +225,7 @@ napi_status napi_is_error(napi_env env, napi_value value, bool* result)
 ### *napi_is_typedarray*
 
 #### Signature
-```
+```C
 napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 ```
 
@@ -240,7 +240,7 @@ napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 ### *napi_strict_equals*
 
 #### Signature
-```
+```C
 napi_status napi_strict_equals(napi_env env,
                                napi_value lhs,
                                napi_value rhs,
@@ -257,7 +257,7 @@ napi_status napi_strict_equals(napi_env env,
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents the invocation of the strict equality algorithm as 
+This N-API API represents the invocation of the Strict Equality algorithm as 
 defined in 
 [Section 7.2.14](https://tc39.github.io/ecma262/#sec-strict-equality-comparison) 
 of the ECMAScript Language Specification.

--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -1,0 +1,238 @@
+# N-API - Abstract Operations 
+
+N-API exposes a set of APIs to apply some abstract operations on JavaScript Objects.
+Some of these operations are documented under [Section 7](https://tc39.github.io/ecma262/#sec-abstract-operations) 
+of the [ECMAScript Language Specification](https://tc39.github.io/ecma262/).
+
+These APIs allow you to do one of the following:
+1. Coerce JavaScript objects to fundamental JavaScript types
+2. Check the type of a JavaScript object
+3. Check for equality between two JavaScript Objects
+
+## Functions
+
+### *napi_coerce_to_bool*
+
+#### Signature
+```
+napi_status napi_coerce_to_bool(napi_env env, napi_value value, napi_value* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to coerce
+- `[out] result`: `napi_value` representing the coerced JavaScript Boolean
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This API implements the abstract operation ToBoolean as defined in [Section 7.1.2](https://tc39.github.io/ecma262/#sec-toboolean)
+of the ECMAScript Language Specification. 
+This API can be re-entrant if getters are defined on the passed in Object.
+
+### *napi_coerce_to_number*
+
+#### Signature
+```
+napi_status napi_coerce_to_number(napi_env env, napi_value value, napi_value* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to coerce
+- `[out] result`: `napi_value` representing the coerced JavaScript Number
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API implements the abstract operation ToNumber as defined in [Section 7.1.3](https://tc39.github.io/ecma262/#sec-tonumber)
+of the ECMAScript Language Specification.
+This API can be re-entrant if getters are defined on the passed in Object.
+
+### *napi_coerce_to_object*
+
+#### Signature
+```
+napi_status napi_coerce_to_object(napi_env env, napi_value value, napi_value* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to coerce
+- `[out] result`: `napi_value` representing the coerced JavaScript Object
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API implements the abstract operation ToObject as defined in [Section 7.1.13](https://tc39.github.io/ecma262/#sec-toobject)
+of the ECMAScript Language Specification.
+This API can be re-entrant if getters are defined on the passed in Object.
+
+### *napi_coerce_to_string*
+
+#### Signature
+```
+napi_status napi_coerce_to_string(napi_env env, napi_value value, napi_value* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to coerce
+- `[out] result`: `napi_value` representing the coerced JavaScript String
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API implements the abstract operation ToString as defined in [Section 7.1.13](https://tc39.github.io/ecma262/#sec-tostring)
+of the ECMAScript Language Specification.
+This API can be re-entrant if getters are defined on the passed-in Object.
+
+### *napi_typeof*
+
+#### Signature
+```
+napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object whose type to query
+- `[out] result`: The type of the JavaScript object
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API represents behavior similar to invoking `typeof` Operator on the object 
+as defined in [Section 12.5.5](https://tc39.github.io/ecma262/#sec-typeof-operator)
+of the ECMAScript Language Specification.
+However, it has support for detecting External objects, and also defaults to `napi_object`
+
+### *napi_instanceof*
+
+#### Signature
+```
+napi_status napi_instanceof(napi_env env, napi_value object, napi_value constructor, bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  object`: The JavaScript object to check
+- `[in]  constructor`: The JavaScript function object of the constructor function to check against
+- `[out] result`: Whether `object instanceof constructor` is true.
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API represents invoking `instanceof` Operator on the object 
+as defined in [Section 12.10.4](https://tc39.github.io/ecma262/#sec-instanceofoperator)
+of the ECMAScript Language Specification.
+
+### *napi_is_array*
+
+#### Signature
+```
+napi_status napi_is_array(napi_env env, napi_value value, bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to check
+- `[out] result`: Whether the given object is an array
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API represents invoking `IsArray` operation on the object 
+as defined in [Section 7.2.2](https://tc39.github.io/ecma262/#sec-isarray)
+of the ECMAScript Language Specification.
+
+### *napi_is_arraybuffer*
+
+#### Signature
+```
+napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to check
+- `[out] result`: Whether the given object is an ArrayBuffer
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+### *napi_is_buffer*
+
+#### Signature
+```
+napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to check
+- `[out] result`: Whether the given object is an N-API representation of node-Buffer
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+### *napi_is_error*
+
+#### Signature
+```
+napi_status napi_is_error(napi_env env, napi_value value, bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to check
+- `[out] result`: Whether the given `napi_value` represents an Error object
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+### *napi_is_typedarray*
+
+#### Signature
+```
+napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  value`: The JavaScript object to check
+- `[out] result`: Whether the given `napi_value` represents an TypedArray
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+### *napi_strict_equals*
+
+#### Signature
+```
+napi_status napi_strict_equals(napi_env env,
+                               napi_value lhs,
+                               napi_value rhs,
+                               bool* result)
+```
+
+#### Parameters
+- `[in]  env`: The environment that the API is invoked under
+- `[in]  lhs`: The JavaScript object to check
+- `[in]  rhs`: The JavaScript object to check against
+- `[out] result`: Whether the two `napi_value` objects are equal
+
+#### Return value
+- `napi_ok` if the API succeeded.
+
+#### Description
+This N-API API represents the invocation of the strict equality algorithm 
+as defined in [Section 7.2.14](https://tc39.github.io/ecma262/#sec-strict-equality-comparison) 
+of the ECMAScript Language Specification.

--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -1,7 +1,7 @@
 # N-API - Abstract Operations 
 
-N-API exposes a set of APIs to apply some abstract operations on JavaScript 
-Objects. Some of these operations are documented under 
+N-API exposes a set of APIs to perform some abstract operations on JavaScript 
+values. Some of these operations are documented under 
 [Section 7](https://tc39.github.io/ecma262/#sec-abstract-operations) 
 of the [ECMAScript Language Specification](https://tc39.github.io/ecma262/).
 
@@ -9,7 +9,7 @@ These APIs allow you to do one of the following:
 1. Coerce JavaScript values to specific JavaScript types (such as Number or
    String)
 2. Check the type of a JavaScript value
-3. Check for equality between two JavaScript Objects
+3. Check for equality between two JavaScript values
 
 ## Functions
 
@@ -54,7 +54,7 @@ napi_status napi_coerce_to_number(napi_env env,
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API implements the abstract operation ToNumber as defined in 
+This API implements the abstract operation ToNumber as defined in 
 [Section 7.1.3](https://tc39.github.io/ecma262/#sec-tonumber)
 of the ECMAScript Language Specification.
 This API can be re-entrant if getters are defined on the passed-in Object.
@@ -77,7 +77,7 @@ napi_status napi_coerce_to_object(napi_env env,
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API implements the abstract operation ToObject as defined in 
+This API implements the abstract operation ToObject as defined in 
 [Section 7.1.13](https://tc39.github.io/ecma262/#sec-toobject)
 of the ECMAScript Language Specification.
 This API can be re-entrant if getters are defined on the passed-in Object.
@@ -100,7 +100,7 @@ napi_status napi_coerce_to_string(napi_env env,
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API implements the abstract operation ToString as defined in 
+This API implements the abstract operation ToString as defined in 
 [Section 7.1.13](https://tc39.github.io/ecma262/#sec-tostring)
 of the ECMAScript Language Specification.
 This API can be re-entrant if getters are defined on the passed-in Object.
@@ -123,11 +123,11 @@ napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
  `value` is not an External value.
 
 #### Description
-This N-API API represents behavior similar to invoking the `typeof` Operator on 
+This API represents behavior similar to invoking the `typeof` Operator on 
 the object as defined in 
 [Section 12.5.5](https://tc39.github.io/ecma262/#sec-typeof-operator)
 of the ECMAScript Language Specification. However, it has support for 
-detecting External value. If `value` has a type that is invalid, an error is
+detecting an External value. If `value` has a type that is invalid, an error is
 returned.
 
 ### *napi_instanceof*
@@ -151,7 +151,7 @@ function to check against
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents invoking the `instanceof` Operator on the object as 
+This API represents invoking the `instanceof` Operator on the object as 
 defined in 
 [Section 12.10.4](https://tc39.github.io/ecma262/#sec-instanceofoperator)
 of the ECMAScript Language Specification.
@@ -172,7 +172,7 @@ napi_status napi_is_array(napi_env env, napi_value value, bool* result)
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents invoking the `IsArray` operation on the object 
+This API represents invoking the `IsArray` operation on the object 
 as defined in [Section 7.2.2](https://tc39.github.io/ecma262/#sec-isarray)
 of the ECMAScript Language Specification.
 
@@ -201,8 +201,8 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
 - `[in]  value`: The JavaScript value to check
-- `[out] result`: Whether the given object is an N-API representation of 
-node::Buffer
+- `[out] result`: Whether the given `napi_value` represents a `node::Buffer`
+object
 
 #### Return value
 - `napi_ok` if the API succeeded.
@@ -257,7 +257,7 @@ napi_status napi_strict_equals(napi_env env,
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents the invocation of the Strict Equality algorithm as 
+This API represents the invocation of the Strict Equality algorithm as 
 defined in 
 [Section 7.2.14](https://tc39.github.io/ecma262/#sec-strict-equality-comparison) 
 of the ECMAScript Language Specification.

--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -34,7 +34,7 @@ napi_status napi_coerce_to_bool(napi_env env,
 This API implements the abstract operation ToBoolean as defined in 
 [Section 7.1.2](https://tc39.github.io/ecma262/#sec-toboolean)
 of the ECMAScript Language Specification. 
-This API can be re-entrant if getters are defined on the passed in Object.
+This API can be re-entrant if getters are defined on the passed-in Object.
 
 ### *napi_coerce_to_number*
 
@@ -57,7 +57,7 @@ napi_status napi_coerce_to_number(napi_env env,
 This N-API API implements the abstract operation ToNumber as defined in 
 [Section 7.1.3](https://tc39.github.io/ecma262/#sec-tonumber)
 of the ECMAScript Language Specification.
-This API can be re-entrant if getters are defined on the passed in Object.
+This API can be re-entrant if getters are defined on the passed-in Object.
 
 ### *napi_coerce_to_object*
 
@@ -80,7 +80,7 @@ napi_status napi_coerce_to_object(napi_env env,
 This N-API API implements the abstract operation ToObject as defined in 
 [Section 7.1.13](https://tc39.github.io/ecma262/#sec-toobject)
 of the ECMAScript Language Specification.
-This API can be re-entrant if getters are defined on the passed in Object.
+This API can be re-entrant if getters are defined on the passed-in Object.
 
 ### *napi_coerce_to_string*
 
@@ -123,7 +123,7 @@ napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
  `value` is not an External value.
 
 #### Description
-This N-API API represents behavior similar to invoking `typeof` Operator on 
+This N-API API represents behavior similar to invoking the `typeof` Operator on 
 the object as defined in 
 [Section 12.5.5](https://tc39.github.io/ecma262/#sec-typeof-operator)
 of the ECMAScript Language Specification. However, it has support for 
@@ -151,7 +151,7 @@ function to check against
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents invoking `instanceof` Operator on the object as 
+This N-API API represents invoking the `instanceof` Operator on the object as 
 defined in 
 [Section 12.10.4](https://tc39.github.io/ecma262/#sec-instanceofoperator)
 of the ECMAScript Language Specification.
@@ -172,7 +172,7 @@ napi_status napi_is_array(napi_env env, napi_value value, bool* result)
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents invoking `IsArray` operation on the object 
+This N-API API represents invoking the `IsArray` operation on the object 
 as defined in [Section 7.2.2](https://tc39.github.io/ecma262/#sec-isarray)
 of the ECMAScript Language Specification.
 
@@ -202,7 +202,7 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 - `[in]  env`: The environment that the API is invoked under
 - `[in]  value`: The JavaScript value to check
 - `[out] result`: Whether the given object is an N-API representation of 
-node-Buffer
+node::Buffer
 
 #### Return value
 - `napi_ok` if the API succeeded.
@@ -232,7 +232,7 @@ napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
 - `[in]  value`: The JavaScript value to check
-- `[out] result`: Whether the given `napi_value` represents an TypedArray
+- `[out] result`: Whether the given `napi_value` represents a TypedArray
 
 #### Return value
 - `napi_ok` if the API succeeded.

--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -1,11 +1,12 @@
 # N-API - Abstract Operations 
 
-N-API exposes a set of APIs to apply some abstract operations on JavaScript Objects.
-Some of these operations are documented under [Section 7](https://tc39.github.io/ecma262/#sec-abstract-operations) 
+N-API exposes a set of APIs to apply some abstract operations on JavaScript 
+Objects. Some of these operations are documented under [Section 7](https://tc39.github.io/ecma262/#sec-abstract-operations) 
 of the [ECMAScript Language Specification](https://tc39.github.io/ecma262/).
 
 These APIs allow you to do one of the following:
-1. Coerce JavaScript values to specific JavaScript types (such as Number or String)
+1. Coerce JavaScript values to specific JavaScript types (such as Number or
+   String)
 2. Check the type of a JavaScript value
 3. Check for equality between two JavaScript Objects
 
@@ -15,7 +16,9 @@ These APIs allow you to do one of the following:
 
 #### Signature
 ```
-napi_status napi_coerce_to_bool(napi_env env, napi_value value, napi_value* result)
+napi_status napi_coerce_to_bool(napi_env env, 
+                                napi_value value, 
+                                napi_value* result)
 ```
 
 #### Parameters
@@ -27,7 +30,8 @@ napi_status napi_coerce_to_bool(napi_env env, napi_value value, napi_value* resu
 - `napi_ok` if the API succeeded.
 
 #### Description
-This API implements the abstract operation ToBoolean as defined in [Section 7.1.2](https://tc39.github.io/ecma262/#sec-toboolean)
+This API implements the abstract operation ToBoolean as defined in 
+[Section 7.1.2](https://tc39.github.io/ecma262/#sec-toboolean)
 of the ECMAScript Language Specification. 
 This API can be re-entrant if getters are defined on the passed in Object.
 
@@ -35,7 +39,9 @@ This API can be re-entrant if getters are defined on the passed in Object.
 
 #### Signature
 ```
-napi_status napi_coerce_to_number(napi_env env, napi_value value, napi_value* result)
+napi_status napi_coerce_to_number(napi_env env, 
+                                  napi_value value, 
+                                  napi_value* result)
 ```
 
 #### Parameters
@@ -47,7 +53,8 @@ napi_status napi_coerce_to_number(napi_env env, napi_value value, napi_value* re
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API implements the abstract operation ToNumber as defined in [Section 7.1.3](https://tc39.github.io/ecma262/#sec-tonumber)
+This N-API API implements the abstract operation ToNumber as defined in 
+[Section 7.1.3](https://tc39.github.io/ecma262/#sec-tonumber)
 of the ECMAScript Language Specification.
 This API can be re-entrant if getters are defined on the passed in Object.
 
@@ -55,7 +62,9 @@ This API can be re-entrant if getters are defined on the passed in Object.
 
 #### Signature
 ```
-napi_status napi_coerce_to_object(napi_env env, napi_value value, napi_value* result)
+napi_status napi_coerce_to_object(napi_env env, 
+                                  napi_value value,
+                                  napi_value* result)
 ```
 
 #### Parameters
@@ -67,7 +76,8 @@ napi_status napi_coerce_to_object(napi_env env, napi_value value, napi_value* re
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API implements the abstract operation ToObject as defined in [Section 7.1.13](https://tc39.github.io/ecma262/#sec-toobject)
+This N-API API implements the abstract operation ToObject as defined in 
+[Section 7.1.13](https://tc39.github.io/ecma262/#sec-toobject)
 of the ECMAScript Language Specification.
 This API can be re-entrant if getters are defined on the passed in Object.
 
@@ -75,7 +85,9 @@ This API can be re-entrant if getters are defined on the passed in Object.
 
 #### Signature
 ```
-napi_status napi_coerce_to_string(napi_env env, napi_value value, napi_value* result)
+napi_status napi_coerce_to_string(napi_env env, 
+                                  napi_value value, 
+                                  napi_value* result)
 ```
 
 #### Parameters
@@ -87,7 +99,8 @@ napi_status napi_coerce_to_string(napi_env env, napi_value value, napi_value* re
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API implements the abstract operation ToString as defined in [Section 7.1.13](https://tc39.github.io/ecma262/#sec-tostring)
+This N-API API implements the abstract operation ToString as defined in 
+[Section 7.1.13](https://tc39.github.io/ecma262/#sec-tostring)
 of the ECMAScript Language Specification.
 This API can be re-entrant if getters are defined on the passed-in Object.
 
@@ -105,33 +118,41 @@ napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
 
 #### Return value
 - `napi_ok` if the API succeeded.
-- `napi_invalid_arg` if the type of `value` is not a known ECMAScript type and `value` is not an External value.
+- `napi_invalid_arg` if the type of `value` is not a known ECMAScript type and
+ `value` is not an External value.
 
 #### Description
-This N-API API represents behavior similar to invoking `typeof` Operator on the object 
-as defined in [Section 12.5.5](https://tc39.github.io/ecma262/#sec-typeof-operator)
-of the ECMAScript Language Specification. However, it has support for detecting External value.
-If `value` has a type that is invalid, an error is returned.
+This N-API API represents behavior similar to invoking `typeof` Operator on 
+the object as defined in 
+[Section 12.5.5](https://tc39.github.io/ecma262/#sec-typeof-operator)
+of the ECMAScript Language Specification. However, it has support for 
+detecting External value. If `value` has a type that is invalid, an error is
+returned.
 
 ### *napi_instanceof*
 
 #### Signature
 ```
-napi_status napi_instanceof(napi_env env, napi_value object, napi_value constructor, bool* result)
+napi_status napi_instanceof(napi_env env, 
+                            napi_value object, 
+                            napi_value constructor, 
+                            bool* result)
 ```
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
 - `[in]  object`: The JavaScript value to check
-- `[in]  constructor`: The JavaScript function object of the constructor function to check against
+- `[in]  constructor`: The JavaScript function object of the constructor 
+function to check against
 - `[out] result`: Whether `object instanceof constructor` is true.
 
 #### Return value
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents invoking `instanceof` Operator on the object 
-as defined in [Section 12.10.4](https://tc39.github.io/ecma262/#sec-instanceofoperator)
+This N-API API represents invoking `instanceof` Operator on the object as 
+defined in 
+[Section 12.10.4](https://tc39.github.io/ecma262/#sec-instanceofoperator)
 of the ECMAScript Language Specification.
 
 ### *napi_is_array*
@@ -179,7 +200,8 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
 - `[in]  value`: The JavaScript value to check
-- `[out] result`: Whether the given object is an N-API representation of node-Buffer
+- `[out] result`: Whether the given object is an N-API representation of 
+node-Buffer
 
 #### Return value
 - `napi_ok` if the API succeeded.
@@ -234,6 +256,7 @@ napi_status napi_strict_equals(napi_env env,
 - `napi_ok` if the API succeeded.
 
 #### Description
-This N-API API represents the invocation of the strict equality algorithm 
-as defined in [Section 7.2.14](https://tc39.github.io/ecma262/#sec-strict-equality-comparison) 
+This N-API API represents the invocation of the strict equality algorithm as 
+defined in 
+[Section 7.2.14](https://tc39.github.io/ecma262/#sec-strict-equality-comparison) 
 of the ECMAScript Language Specification.

--- a/napi_abstract.md
+++ b/napi_abstract.md
@@ -5,8 +5,8 @@ Some of these operations are documented under [Section 7](https://tc39.github.io
 of the [ECMAScript Language Specification](https://tc39.github.io/ecma262/).
 
 These APIs allow you to do one of the following:
-1. Coerce JavaScript objects to fundamental JavaScript types
-2. Check the type of a JavaScript object
+1. Coerce JavaScript values to specific JavaScript types (such as Number or String)
+2. Check the type of a JavaScript value
 3. Check for equality between two JavaScript Objects
 
 ## Functions
@@ -20,7 +20,7 @@ napi_status napi_coerce_to_bool(napi_env env, napi_value value, napi_value* resu
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to coerce
+- `[in]  value`: The JavaScript value to coerce
 - `[out] result`: `napi_value` representing the coerced JavaScript Boolean
 
 #### Return value
@@ -40,7 +40,7 @@ napi_status napi_coerce_to_number(napi_env env, napi_value value, napi_value* re
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to coerce
+- `[in]  value`: The JavaScript value to coerce
 - `[out] result`: `napi_value` representing the coerced JavaScript Number
 
 #### Return value
@@ -60,7 +60,7 @@ napi_status napi_coerce_to_object(napi_env env, napi_value value, napi_value* re
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to coerce
+- `[in]  value`: The JavaScript value to coerce
 - `[out] result`: `napi_value` representing the coerced JavaScript Object
 
 #### Return value
@@ -80,7 +80,7 @@ napi_status napi_coerce_to_string(napi_env env, napi_value value, napi_value* re
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to coerce
+- `[in]  value`: The JavaScript value to coerce
 - `[out] result`: `napi_value` representing the coerced JavaScript String
 
 #### Return value
@@ -100,17 +100,18 @@ napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object whose type to query
-- `[out] result`: The type of the JavaScript object
+- `[in]  value`: The JavaScript value whose type to query
+- `[out] result`: The type of the JavaScript value
 
 #### Return value
 - `napi_ok` if the API succeeded.
+- `napi_invalid_arg` if the type of `value` is not a known ECMAScript type and `value` is not an External value.
 
 #### Description
 This N-API API represents behavior similar to invoking `typeof` Operator on the object 
 as defined in [Section 12.5.5](https://tc39.github.io/ecma262/#sec-typeof-operator)
-of the ECMAScript Language Specification.
-However, it has support for detecting External objects, and also defaults to `napi_object`
+of the ECMAScript Language Specification. However, it has support for detecting External value.
+If `value` has a type that is invalid, an error is returned.
 
 ### *napi_instanceof*
 
@@ -121,7 +122,7 @@ napi_status napi_instanceof(napi_env env, napi_value object, napi_value construc
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  object`: The JavaScript object to check
+- `[in]  object`: The JavaScript value to check
 - `[in]  constructor`: The JavaScript function object of the constructor function to check against
 - `[out] result`: Whether `object instanceof constructor` is true.
 
@@ -142,7 +143,7 @@ napi_status napi_is_array(napi_env env, napi_value value, bool* result)
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to check
+- `[in]  value`: The JavaScript value to check
 - `[out] result`: Whether the given object is an array
 
 #### Return value
@@ -162,7 +163,7 @@ napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result)
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to check
+- `[in]  value`: The JavaScript value to check
 - `[out] result`: Whether the given object is an ArrayBuffer
 
 #### Return value
@@ -177,7 +178,7 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to check
+- `[in]  value`: The JavaScript value to check
 - `[out] result`: Whether the given object is an N-API representation of node-Buffer
 
 #### Return value
@@ -192,7 +193,7 @@ napi_status napi_is_error(napi_env env, napi_value value, bool* result)
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to check
+- `[in]  value`: The JavaScript value to check
 - `[out] result`: Whether the given `napi_value` represents an Error object
 
 #### Return value
@@ -207,7 +208,7 @@ napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  value`: The JavaScript object to check
+- `[in]  value`: The JavaScript value to check
 - `[out] result`: Whether the given `napi_value` represents an TypedArray
 
 #### Return value
@@ -225,8 +226,8 @@ napi_status napi_strict_equals(napi_env env,
 
 #### Parameters
 - `[in]  env`: The environment that the API is invoked under
-- `[in]  lhs`: The JavaScript object to check
-- `[in]  rhs`: The JavaScript object to check against
+- `[in]  lhs`: The JavaScript value to check
+- `[in]  rhs`: The JavaScript value to check against
 - `[out] result`: Whether the two `napi_value` objects are equal
 
 #### Return value


### PR DESCRIPTION
First cut at API documentation for N-API operations that fall under the "Abstract Operations" section in the ECMA262 spec. 

Ref: #153