### PR TITLE
add emnapi to node-api-engine-bindings.md

### DIFF
--- a/node-api-engine-bindings.md
+++ b/node-api-engine-bindings.md
@@ -67,6 +67,7 @@ language to implement native addons for Node.js through Node-API:
 |[electron](https://github.com/electron/electron)| C++|
 |[iotjs](https://github.com/jerryscript-project/iotjs)| C|
 |[veil](https://github.com/lightsourceengine/veil)| C|
+|[emnapi](https://github.com/toyobayashi/emnapi)| C / JavaScript|
 
 [ABI stability guide]: https://nodejs.org/en/docs/guides/abi-stability/
 [ECMA262 Language Specification]: https://tc39.es/ecma262/

--- a/node-api-engine-bindings.md
+++ b/node-api-engine-bindings.md
@@ -65,9 +65,9 @@ language to implement native addons for Node.js through Node-API:
 |[bun](https://github.com/oven-sh/bun)| Zig|
 |[deno](https://github.com/denoland/deno)| Rust|
 |[electron](https://github.com/electron/electron)| C++|
+|[emnapi](https://github.com/toyobayashi/emnapi)| C / JavaScript|
 |[iotjs](https://github.com/jerryscript-project/iotjs)| C|
 |[veil](https://github.com/lightsourceengine/veil)| C|
-|[emnapi](https://github.com/toyobayashi/emnapi)| C / JavaScript|
 
 [ABI stability guide]: https://nodejs.org/en/docs/guides/abi-stability/
 [ECMA262 Language Specification]: https://tc39.es/ecma262/


### PR DESCRIPTION
https://github.com/nodejs/node-addon-api/pull/1283#issuecomment-1427637888

Not sure if it is the correct position to add. emnapi is not a "runtime", but something (a library?) that can help users write bindings between wasm and JavaScript in a same way of Node-API, itself need to be run on a JavaScript runtime such as browser or Node.js.
