### PR TITLE
Update list of videos and add video preview cards.

### DIFF
--- a/node-api-media.md
+++ b/node-api-media.md
@@ -17,8 +17,3 @@ principles for creating native Node.js modules using Node-API.
 |**N-API: The Next Generation Node.js API is Ready!**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Oct 17, 2018|[![N-API: The Next Generation Node.js API is Ready video](https://img.youtube.com/vi/BrJcsYjp8Nw/0.jpg)](https://www.youtube.com/watch?v=BrJcsYjp8Nw)|
 |**N-API - next generation Node API for native modules**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Nov 6, 2017|[![N-API - next generation Node API for native modules video](https://img.youtube.com/vi/E848bgHfoxE/0.jpg)](https://www.youtube.com/watch?v=E848bgHfoxE)|
 |**N-API - Next Generation Node API for Native Modules**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Oct 15, 2017|[![N-API - Next Generation Node API for Native Modules video](https://img.youtube.com/vi/-Oniup60Afs/0.jpg)](https://www.youtube.com/watch?v=-Oniup60Afs)|
-
-<style>
-/* To align text in table cells */
-td { vertical-align: top; }
-</style>

--- a/node-api-media.md
+++ b/node-api-media.md
@@ -8,9 +8,17 @@ principles for creating native Node.js modules using Node-API.
 
 |Title|Link|
 |----|-----|
-|N-API - Next Generation Node API for Native Modules|https://www.youtube.com/watch?v=-Oniup60Afs|
-|N-API: The Next Generation Node.js API is Ready! - Michael Dawson, IBM & Arunesh Chandra, Microsoft|https://www.youtube.com/watch?v=BrJcsYjp8Nw|
-|Next Generation N-API: A Hands-on Workshop - Nicola Del Gobbo, Packly & Jim Schlight, Inspiredware|https://www.youtube.com/watch?v=-v4Q0y4CeRA|
-|Building Modern Native Add-ons for Node.js in 2021 - Kevin Eady, Hive Streaming & Gabriel Schulhof|https://www.youtube.com/watch?v=4cCSPw-I0GE|
-|Creating Native Addons - General Principles by Gabriel Schulhof, Intel Finland Oy|https://www.youtube.com/watch?v=UtWP2iR3_DQ|
-|N-API - next generation Node API for native modules - Michael Dawson & Arunesh Chandra|https://www.youtube.com/watch?v=E848bgHfoxE|
+|**Building Node.js native addons like it's 2023**<br/>Michael Dawson, IBM<br/>May 16, 2023|[![Building Node.js native addons like it's 2023 video](https://img.youtube.com/vi/jzP8lyYqPzg/0.jpg)](https://www.youtube.com/watch?v=jzP8lyYqPzg&t=3717s)|
+|**Native Code in Node.js in 3 MINS**<br/>FireJet YouTube channel<br/>Jan 28, 2022|[![Native Code in Node.js in 3 MINS video](https://img.youtube.com/vi/CJqERG2rBaU/0.jpg)](https://www.youtube.com/watch?v=CJqERG2rBaU)|
+|**Building Modern Native Add-ons for Node.js in 2021**<br/>Kevin Eady, Hive Streaming & Gabriel Schulhof<br/>Jun 2, 2021|[![Building Modern Native Add-ons for Node.js in 2021 video](https://img.youtube.com/vi/4cCSPw-I0GE/0.jpg)](https://www.youtube.com/watch?v=4cCSPw-I0GE)|
+|**Next Generation N-API: A Hands-on Workshop**<br/>Nicola Del Gobbo, Packly & Jim Schlight, Inspiredware<br/>Dec 18, 2019|[![Next Generation N-API: A Hands-on Workshop video](https://img.youtube.com/vi/-v4Q0y4CeRA/0.jpg)](https://www.youtube.com/watch?v=-v4Q0y4CeRA)|
+|**N-API - The new native in node.js**<br/>Atishay Jain, Adobe<br/>Dec 13, 2018|[![N-API - The new native in node.js video](https://img.youtube.com/vi/E0w7Tc0f2fA/0.jpg)](https://www.youtube.com/watch?v=E0w7Tc0f2fA)|
+|**N-API on JerryScript**<br/>Gabriel Schulhof, Intel<br/>Oct 19, 2018|[![N-API on JerryScript video](https://img.youtube.com/vi/Pxabz_FA1IU/0.jpg)](https://www.youtube.com/watch?v=Pxabz_FA1IU)|
+|**N-API: The Next Generation Node.js API is Ready!**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Oct 17, 2018|[![N-API: The Next Generation Node.js API is Ready video](https://img.youtube.com/vi/BrJcsYjp8Nw/0.jpg)](https://www.youtube.com/watch?v=BrJcsYjp8Nw)|
+|**N-API - next generation Node API for native modules**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Nov 6, 2017|[![N-API - next generation Node API for native modules video](https://img.youtube.com/vi/E848bgHfoxE/0.jpg)](https://www.youtube.com/watch?v=E848bgHfoxE)|
+|**N-API - Next Generation Node API for Native Modules**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Oct 15, 2017|[![N-API - Next Generation Node API for Native Modules video](https://img.youtube.com/vi/-Oniup60Afs/0.jpg)](https://www.youtube.com/watch?v=-Oniup60Afs)|
+
+<style>
+/* To align text in table cells */
+td { vertical-align: top; }
+</style>

--- a/node-api-media.md
+++ b/node-api-media.md
@@ -6,14 +6,133 @@ principles. The following table contains media links to conferences and
 workshops discussing Node-API features, best practices, and general design
 principles for creating native Node.js modules using Node-API.
 
-|Title|Link|
-|----|-----|
-|**Building Node.js native addons like it's 2023**<br/>Michael Dawson, IBM<br/>May 16, 2023|[![Building Node.js native addons like it's 2023 video](https://img.youtube.com/vi/jzP8lyYqPzg/0.jpg)](https://www.youtube.com/watch?v=jzP8lyYqPzg&t=3717s)|
-|**Native Code in Node.js in 3 MINS**<br/>FireJet YouTube channel<br/>Jan 28, 2022|[![Native Code in Node.js in 3 MINS video](https://img.youtube.com/vi/CJqERG2rBaU/0.jpg)](https://www.youtube.com/watch?v=CJqERG2rBaU)|
-|**Building Modern Native Add-ons for Node.js in 2021**<br/>Kevin Eady, Hive Streaming & Gabriel Schulhof<br/>Jun 2, 2021|[![Building Modern Native Add-ons for Node.js in 2021 video](https://img.youtube.com/vi/4cCSPw-I0GE/0.jpg)](https://www.youtube.com/watch?v=4cCSPw-I0GE)|
-|**Next Generation N-API: A Hands-on Workshop**<br/>Nicola Del Gobbo, Packly & Jim Schlight, Inspiredware<br/>Dec 18, 2019|[![Next Generation N-API: A Hands-on Workshop video](https://img.youtube.com/vi/-v4Q0y4CeRA/0.jpg)](https://www.youtube.com/watch?v=-v4Q0y4CeRA)|
-|**N-API - The new native in node.js**<br/>Atishay Jain, Adobe<br/>Dec 13, 2018|[![N-API - The new native in node.js video](https://img.youtube.com/vi/E0w7Tc0f2fA/0.jpg)](https://www.youtube.com/watch?v=E0w7Tc0f2fA)|
-|**N-API on JerryScript**<br/>Gabriel Schulhof, Intel<br/>Oct 19, 2018|[![N-API on JerryScript video](https://img.youtube.com/vi/Pxabz_FA1IU/0.jpg)](https://www.youtube.com/watch?v=Pxabz_FA1IU)|
-|**N-API: The Next Generation Node.js API is Ready!**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Oct 17, 2018|[![N-API: The Next Generation Node.js API is Ready video](https://img.youtube.com/vi/BrJcsYjp8Nw/0.jpg)](https://www.youtube.com/watch?v=BrJcsYjp8Nw)|
-|**N-API - next generation Node API for native modules**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Nov 6, 2017|[![N-API - next generation Node API for native modules video](https://img.youtube.com/vi/E848bgHfoxE/0.jpg)](https://www.youtube.com/watch?v=E848bgHfoxE)|
-|**N-API - Next Generation Node API for Native Modules**<br/>Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>Oct 15, 2017|[![N-API - Next Generation Node API for Native Modules video](https://img.youtube.com/vi/-Oniup60Afs/0.jpg)](https://www.youtube.com/watch?v=-Oniup60Afs)|
+<table>
+<thead><tr><th>Title</th><th>Video Link</th></tr></thead>
+<tbody><tr><td valign="top">
+
+**Building Node.js native addons like it's 2023**<br/>
+Michael Dawson, IBM<br/>
+May 16, 2023
+
+</td><td>
+
+[<img
+  width="300"
+  alt="Building Node.js native addons like it's 2023 video"
+  src="https://img.youtube.com/vi/jzP8lyYqPzg/0.jpg" />
+](https://www.youtube.com/watch?v=jzP8lyYqPzg&t=3717s)
+
+</td></tr><tr><td valign="top">
+
+**Native Code in Node.js in 3 MINS**<br/>
+FireJet YouTube channel<br/>
+Jan 28, 2022
+
+</td><td>
+
+[<img
+  width="300"
+  alt="Native Code in Node.js in 3 MINS video"
+  src="https://img.youtube.com/vi/CJqERG2rBaU/0.jpg" />
+](https://www.youtube.com/watch?v=CJqERG2rBaU)
+
+</td></tr><tr><td valign="top">
+
+**Building Modern Native Add-ons for Node.js in 2021**<br/>
+Kevin Eady, Hive Streaming & Gabriel Schulhof<br/>
+Jun 2, 2021
+
+</td><td>
+
+[<img
+  width="300"
+  alt="Building Modern Native Add-ons for Node.js in 2021 video"
+  src="https://img.youtube.com/vi/4cCSPw-I0GE/0.jpg" />
+](https://www.youtube.com/watch?v=4cCSPw-I0GE)
+
+</td></tr><tr><td valign="top">
+
+**Next Generation N-API: A Hands-on Workshop**<br/>
+Nicola Del Gobbo, Packly & Jim Schlight, Inspiredware<br/>
+Dec 18, 2019
+
+</td><td>
+
+[<img
+  width="300"
+  alt="Next Generation N-API: A Hands-on Workshop video"
+  src="https://img.youtube.com/vi/-v4Q0y4CeRA/0.jpg" />
+](https://www.youtube.com/watch?v=-v4Q0y4CeRA)
+
+</td></tr><tr><td valign="top">
+
+**N-API - The new native in node.js**<br/>
+Atishay Jain, Adobe<br/>
+Dec 13, 2018
+
+</td><td>
+
+[<img
+  width="300"
+  alt="N-API - The new native in node.js video"
+  src="https://img.youtube.com/vi/E0w7Tc0f2fA/0.jpg" />
+](https://www.youtube.com/watch?v=E0w7Tc0f2fA)
+
+</td></tr><tr><td valign="top">
+
+**N-API on JerryScript**<br/>
+Gabriel Schulhof, Intel<br/>
+Oct 19, 2018
+
+</td><td>
+
+[<img
+  width="300"
+  alt="N-API on JerryScript video"
+  src="https://img.youtube.com/vi/Pxabz_FA1IU/0.jpg" />
+](https://www.youtube.com/watch?v=Pxabz_FA1IU)
+
+</td></tr><tr><td valign="top">
+
+**N-API: The Next Generation Node.js API is Ready!**<br/>
+Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>
+Oct 17, 2018
+
+</td><td>
+
+[<img
+  width="300"
+  alt="N-API: The Next Generation Node.js API is Ready video"
+  src="https://img.youtube.com/vi/BrJcsYjp8Nw/0.jpg" />
+](https://www.youtube.com/watch?v=BrJcsYjp8Nw)
+
+</td></tr><tr><td valign="top">
+
+**N-API - next generation Node API for native modules**<br/>
+Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>
+Nov 6, 2017
+
+</td><td>
+
+[<img
+  width="300"
+  alt="N-API - next generation Node API for native modules video"
+  src="https://img.youtube.com/vi/E848bgHfoxE/0.jpg" />
+](https://www.youtube.com/watch?v=E848bgHfoxE)
+
+</td></tr><tr><td valign="top">
+
+**N-API - Next Generation Node API for Native Modules**<br/>
+Michael Dawson, IBM & Arunesh Chandra, Microsoft<br/>
+Oct 15, 2017
+
+</td><td>
+
+[<img
+  width="300"
+  alt="N-API - Next Generation Node API for Native Modules video"
+  src="https://img.youtube.com/vi/-Oniup60Afs/0.jpg" />
+](https://www.youtube.com/watch?v=-Oniup60Afs)
+
+</td></tr></tbody>
+</table>


### PR DESCRIPTION
I wanted to add the new video about Node-API recently presented by @mhdawson, but I ended up doing a bit more changes:
- Formatted video description and added video date.
- Sorted all videos based on the date - the most recent are on top.
- Added preview image cards for all video links.
- Changed the table to use HTML tags to align title vertically and to reduce the image card sizes. It also helped to limit the horizonal size of the file text.
- Updated the list of the videos:
  - Removed one video: 
    - [Creating Native Addons - General Principles](https://www.youtube.com/watch?v=UtWP2iR3_DQ) - it was about NAN, not Node-API.
  - Added new Node-API videos:
    - [Building Node.js native addons like it's 2023](https://www.youtube.com/watch?v=jzP8lyYqPzg&t=3717s)
    - [Native Code in Node.js in 3 MINS](https://www.youtube.com/watch?v=CJqERG2rBaU)
    - [N-API - The new native in node.js](https://www.youtube.com/watch?v=E0w7Tc0f2fA)
    - [N-API on JerryScript](https://www.youtube.com/watch?v=Pxabz_FA1IU)
    
[Preview the file](https://github.com/nodejs/abi-stable-node/blob/a3b3ad6b65d07307a3cb67741734af7e2b7df2a2/node-api-media.md)